### PR TITLE
POL-106 Google Object Storage Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Please contact sales@rightscale.com to learn more.
 - [Google Idle Compute Instances](./cost/google/idle_compute_instances/)
 - [AWS Object Storage Optimization](./cost/aws/object_storage_optimization/)
 - [AWS Unused RDS Instances](./cost/aws/unused_rds/)
+- [Google Object Storage Optimization](./cost/google/object_storage_optimization/)
 
 ### Security
 

--- a/cost/google/object_storage_optimization/CHANGELOG.md
+++ b/cost/google/object_storage_optimization/CHANGELOG.md
@@ -1,0 +1,4 @@
+v1.0
+-----
+- initial release
+

--- a/cost/google/object_storage_optimization/README.md
+++ b/cost/google/object_storage_optimization/README.md
@@ -1,0 +1,48 @@
+## Google Object Storage Optimization
+ 
+### What it does
+
+This Policy checks Google buckets for older objects and can move old object to 'nearline' or 'coldline' after a given period of time. The user can choose to delete old object by enabling 'delete action' option as mentioned in Enable delete action section below.
+
+### Functional Details
+ 
+- This policy identifies all Google storage objects last updated outside of the specified timeframe
+- For all objects identified as old, the user can choose to move the object to 'nearline' or 'coldline' after the specified timeframe.
+- The user can choose to delete old object by enabling 'delete action' option as mentioned in Enable delete action section below.
+ 
+### Input Parameters
+ 
+This policy has the following input parameters required when launching the policy.
+
+- *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
+- *Google Cloud Project Id* - Google Cloud Project Id
+- *Move to Nearline after days last modified* - leave blank to skip moving
+- *Move to coldline after days last modified* - leave blank to skip moving
+- *Exclude Tag* - exclude object with the included tags 
+ 
+### Required RightScale Roles
+ 
+- Cloud Management - The `credential_viewer`,`observer` roles
+- Cloud Management - The `policy_designer`, `policy_manager` & `policy_publisher` roles
+
+### Enable delete action
+
+Perform below steps to enable delete action.
+
+- Edit the file [Google Object Storage Optimization](https://github.com/flexera/policy_templates/tree/master/cost/google/object_storage_optimization/google_object_storage_optimization.pt)
+- uncomment the line which conatins 'escalate $esc_delete_bucket_objects_approval' 
+- comment the line which contains 'escalate $esc_modify_bucket_object_storage_class_approval' and save the changes. and save the changes.
+- upload the modified file and apply the policy.
+
+### Google Required Permissions
+
+- This policy requires IAM permissions to storage.buckets.list, storage.buckets.getIamPolicy2, storage.objects.list, storage.objects.getIamPolicy2,6, storage.objects.create (for the destination bucket), storage.objects.delete (for the destination bucket)4, storage.objects.get (for the source bucket) and storage.objects.delete.
+- Create a service account (if not exists) with the necessary permissions under Google-cloud platform (IAM & admin -> service accounts). Generate key, a JSON file will get downloaded in which you can find 'client email' and 'private key' which has to be added as credentials in RightScale cloud management Design -> Credentials with name 'GCE_PLUGIN_ACCOUNT' and 'GCE_PLUGIN_PRIVATE_KEY' respectively.
+
+### Supported Clouds
+ 
+- Google
+ 
+### Cost
+ 
+This Policy Template does not incur any cloud costs.

--- a/cost/google/object_storage_optimization/google_object_storage_optimization.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization.pt
@@ -225,7 +225,7 @@ policy "google_object_storage_optimization" do
   validate $ds_google_filtered_bucket_objects do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): Google Object Storage Optimization."
     detail_template <<-EOS
-# Found {{ len data }} google bucket Objects which are last modified outside of the specified timeframe.
+# Found {{ len data }} Google bucket objects which are last modified outside of the specified timeframe.
 | Bucket Name | Region | Object Name | Current Storage Class | Last Modified Date | Move Storage Class To | Tags |
 | ----------- | ------ | ----------- | --------------------- | ------------------ | --------------------- | ---- |
 {{ range data -}}
@@ -284,24 +284,26 @@ define modify_bucket_object_storage_class($data) return $all_responses do
   call google_authenticate() retrieve $access_token
   $all_responses = []
   foreach $item in $data do
-    call url_encode($item['bucket_name']) retrieve $bucket_name
-    call url_encode($item['object_name']) retrieve $object_name
-    $response = http_request({
-                              verb: 'post',
-                              host: 'www.googleapis.com',
-                              href: join(['/storage/v1/b/', $bucket_name, '/o/', $object_name, '/rewriteTo/b/', $bucket_name, '/o/', $object_name]),
-                              https: true,
-                              body: {
-                                     "storageClass": $item['modify_storage_class_to']
-                                    },
-                              headers: {
+    sub on_error: skip do
+      call url_encode($item['bucket_name']) retrieve $bucket_name
+      call url_encode($item['object_name']) retrieve $object_name
+      $response = http_request({
+                                verb: 'post',
+                                host: 'www.googleapis.com',
+                                href: join(['/storage/v1/b/', $bucket_name, '/o/', $object_name, '/rewriteTo/b/', $bucket_name, '/o/', $object_name]),
+                                https: true,
+                                body: {
+                                       "storageClass": $item['modify_storage_class_to']
+                                      },
+                                headers: {
                                           "cache-control": "no-cache",
                                           "content-type": "application/json",
                                           "authorization": "Bearer " + $access_token
-                                          }
-                            })
+                                         }
+                              })
       $all_responses << $response
       call sys_log('Google object storage optimization response ',to_s($response))
+    end
   end
 end
 
@@ -311,21 +313,23 @@ define delete_bucket_objects($data) return $all_responses do
   call google_authenticate() retrieve $access_token
   $all_responses = []
   foreach $item in $data do
-    call url_encode($item['bucket_name']) retrieve $bucket_name
-    call url_encode($item['object_name']) retrieve $object_name
-    $response = http_request({
-                              verb: 'delete',
-                              host: 'www.googleapis.com',
-                              href: join(['/storage/v1/b/', $bucket_name, '/o/', $object_name]),
-                              https: true,
-                              headers: {
-                                          "cache-control": "no-cache",
-                                          "content-type": "application/json",
-                                          "authorization": "Bearer " + $access_token
-                                          }
-                            })
+    sub on_error: skip do
+      call url_encode($item['bucket_name']) retrieve $bucket_name
+      call url_encode($item['object_name']) retrieve $object_name
+      $response = http_request({
+                                verb: 'delete',
+                                host: 'www.googleapis.com',
+                                href: join(['/storage/v1/b/', $bucket_name, '/o/', $object_name]),
+                                https: true,
+                                headers: {
+                                            "cache-control": "no-cache",
+                                            "content-type": "application/json",
+                                            "authorization": "Bearer " + $access_token
+                                            }
+                              })
       $all_responses << $response
       call sys_log('Google Storage optimization delete response ',to_s($response))
+    end
   end
 end
 

--- a/cost/google/object_storage_optimization/google_object_storage_optimization.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization.pt
@@ -1,0 +1,395 @@
+name "Google Object Storage Optimization"
+rs_pt_ver 20180301
+type "policy"
+short_description "Checks Google Storage objects for last updated time and moves the object to 'nearline' or 'coldline' or delete(enable delete action as mentioned in README.md) after user approval [README](https://github.com/flexera/policy_templates/tree/master/cost/google/object_storage_optimization) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
+long_description "Version: 1.0"
+category "Cost"
+severity "low"
+
+###############################################################################
+# Permissions
+###############################################################################
+
+permission "perm_read_creds" do
+  actions   "rs_cm.show_sensitive","rs_cm.index_sensitive"
+  resources "rs_cm.credentials"
+end
+
+###############################################################################
+# User inputs
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+end
+
+parameter "param_google_project" do
+  type "string"
+  label "Google Cloud Project Id"
+  allowed_pattern /^[0-9a-z:\.-]+$/
+end
+
+parameter "param_nearline_days" do
+  type "string"
+  label "Days since last modified to move to nearline"
+  description "Move to nearline after days last modified - leave blank to skip moving"
+end
+
+parameter "param_coldline_days" do
+  type "string"
+  label "Days since last modified to move to coldline"
+  description "Move to coldline after days last modified- leave blank to skip moving"
+end
+
+parameter "param_exclude_tags" do
+  type "list"
+  label "Tags to ignore"
+  description "List of tags(Key or Key, value mentioned in object metadata.) that will exclude objects from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+auth "auth_google", type: "oauth2" do
+  token_url "https://www.googleapis.com/oauth2/v4/token"
+  grant type: "jwt_bearer" do
+    iss cred("GCE_PLUGIN_ACCOUNT")
+    aud "https://www.googleapis.com/oauth2/v4/token"
+    additional_claims do {
+      "scope" => "https://www.googleapis.com/auth/devstorage.full_control"
+    } end
+    signing_key cred("GCE_PLUGIN_PRIVATE_KEY")
+  end
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "google_pagination" do
+  get_page_marker do
+    body_path "nextPageToken"
+  end
+  set_page_marker do
+    query "pageToken"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+#https://cloud.google.com/storage/docs/json_api/v1/buckets/list
+datasource "ds_list_google_buckets" do
+  request do
+    auth $auth_google
+    pagination $google_pagination
+    verb "GET"
+    host "www.googleapis.com"
+    path "/storage/v1/b"
+    query "project", $param_google_project
+    query "projection", "noAcl"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "items[*]") do
+      field "bucket_name", jmes_path(col_item, "name")
+      field "location", jmes_path(col_item, "location")
+    end
+  end
+end
+
+#https://cloud.google.com/storage/docs/json_api/v1/objects/list
+datasource "ds_list_google_buckets_objects" do
+  iterate $ds_list_google_buckets
+  request do
+    auth $auth_google
+    pagination $google_pagination
+    verb "GET"
+    host "www.googleapis.com"
+    path join(["/storage/v1/b/",val(iter_item, "bucket_name"),"/o"])
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "items[*]") do
+      field "bucket_name", jmes_path(col_item, "bucket")
+      field "creation_date", jmes_path(col_item, "timeCreated")
+      field "region", val(iter_item, "location")
+      field "object_name", jmes_path(col_item, "name")
+      field "storage_class", jmes_path(col_item, "storageClass")
+      field "last_modified", jmes_path(col_item, "updated")
+      field "object_size", jmes_path(col_item, "size")
+      field "metadata", jmes_path(col_item, "metadata")
+    end
+  end
+end
+
+datasource "ds_google_filtered_bucket_objects" do
+  run_script $js_google_filtered_bucket_objects, $ds_list_google_buckets_objects, $param_exclude_tags, $param_nearline_days, $param_coldline_days
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+#Process the response data, check for the tags and generate a list of bucket objects.
+script "js_google_filtered_bucket_objects", type: "javascript" do
+  parameters "ds_list_google_buckets_objects", "param_exclude_tags", "param_nearline_days", "param_coldline_days"
+  result "results"
+  code <<-EOS
+    results = [];
+    var param_exclude_tags_lower=[];
+    for(var i=0; i < param_exclude_tags.length; i++){
+      param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
+    }
+    var nearline_date = new Date();
+    var coldline_date = new Date();
+    var nearline_days_to_move = parseInt(param_nearline_days,10);
+    var coldline_days_to_move = parseInt(param_coldline_days,10);
+    nearline_date = nearline_date.setDate(nearline_date.getDate() - nearline_days_to_move);
+    coldline_date = coldline_date.setDate(coldline_date.getDate() - coldline_days_to_move);
+    nearline_date = (new Date(nearline_date)).setHours(23, 59, 59, 999);
+    coldline_date =(new Date(coldline_date)).setHours(23, 59, 59, 999);
+
+    _.each(ds_list_google_buckets_objects, function(bucket_object){
+      var tags = bucket_object['metadata'];
+      var isTagMatched=false
+      var tagKeyValue=""
+      if(typeof(tags) !== "undefined"){
+        var tagKeys = Object.keys(tags);
+        for (var j = 0; j < tagKeys.length; j++){
+          var tagKey = tagKeys[j];
+          var tagValue = tags[tagKey];
+          //Check, if the tag present in entered param_exclude_tags, ignore the google bucket object if the tag matches/present.
+          if((param_exclude_tags_lower.indexOf(tagKey.toLowerCase()) !== -1) || (param_exclude_tags_lower.indexOf((tagKey+'='+tagValue).toLowerCase()) !== -1)){
+            isTagMatched = true;
+          }
+          if(tagValue.length > 0){
+            tagKeyValue = tagKeyValue + ', '+ tagKey+'='+tagValue
+          }else{
+            tagKeyValue = tagKeyValue + ', '+ tagKey
+          }
+        }
+      }
+
+      if(isTagMatched && bucket_object.storage_class !== "nearline" && bucket_object.storage_class !== "coldline"){
+        var last_modified_date = (new Date(bucket_object["last_modified"])).setHours(23, 59, 59, 999);
+        var modify_storage_class_to="";
+        if(param_nearline_days.length > 0 && param_coldline_days.length == 0 &&  last_modified_date <= nearline_date){
+          //When param_coldline_days is blank.
+          modify_storage_class_to = "nearline";
+        }else if(param_nearline_days.length == 0 && param_coldline_days.length > 0 && last_modified_date <= coldline_date){
+          //When param_nearline_days is blank.
+          modify_storage_class_to = "coldline";
+        }else if(param_nearline_days.length > 0 && param_coldline_days.length > 0 && (last_modified_date <= nearline_date || last_modified_date <= coldline_date)){
+          if(nearline_days_to_move < coldline_days_to_move){
+            if(last_modified_date <= nearline_date && last_modified_date >= coldline_date){
+              modify_storage_class_to = "nearline";
+            }else{
+              modify_storage_class_to = "coldline";
+            }
+          }else if(nearline_days_to_move > coldline_days_to_move){
+            if(last_modified_date <= coldline_date && last_modified_date >= nearline_date){
+              modify_storage_class_to = "coldline";
+            }else{
+              modify_storage_class_to = "nearline";
+            }
+          }
+        }
+        if(modify_storage_class_to.length > 0){
+          results.push({
+            "bucket_name": bucket_object["bucket_name"],
+            "creation_date": bucket_object["creation_date"],
+            "region":bucket_object["region"],
+            "object_name": bucket_object["object_name"],
+            "storage_class": bucket_object["storage_class"],
+            "last_modified": bucket_object["last_modified"],
+            "modify_storage_class_to": modify_storage_class_to,
+            "object_size": bucket_object["object_size"],
+            "tagKeyValue":(tagKeyValue.slice(2))
+          });
+        }
+      }
+    });
+  EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "google_object_storage_optimization" do
+  validate $ds_google_filtered_bucket_objects do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): Google Object Storage Optimization."
+    detail_template <<-EOS
+# Found {{ len data }} google bucket Objects which are last modified outside of the specified timeframe.
+| Bucket Name | Region | Object Name | Current Storage Class | Last Modified Date | Move Storage Class To | Tags |
+| ----------- | ------ | ----------- | --------------------- | ------------------ | --------------------- | ---- |
+{{ range data -}}
+| {{.bucket_name}} | {{.region}} | {{.object_name}} | {{.storage_class}} | {{.last_modified}} | {{.modify_storage_class_to}} | {{.tagKeyValue}}
+{{ end -}}
+    EOS
+    escalate $esc_report_bucket_Objects_list
+    escalate $esc_modify_bucket_object_storage_class_approval
+    #Uncomment below line (remove '#') to enable Delete action and comment above line(add '#').
+    #escalate $esc_delete_bucket_objects_approval
+    check eq(size(data),0)
+  end
+end
+
+###############################################################################
+# Escalation
+###############################################################################
+
+escalation "esc_report_bucket_Objects_list" do
+  email $param_email
+end
+
+escalation "esc_modify_bucket_object_storage_class_approval" do
+  request_approval  do
+    label "Approve Google Bucket object storage class Change"
+    description "Approve escalation to run RightScale Cloud Workflow to update storage class for bucket objects"
+    parameter "approval_reason" do
+      type "string"
+      label "Reason for Approval"
+      description "Explain why you are approving the action."
+    end
+  end
+  run "modify_bucket_object_storage_class", data
+end
+
+escalation "esc_delete_bucket_objects_approval" do
+  request_approval  do
+    label "Approve Google Bucket object Deletion"
+    description "Approve escalation to run RightScale Cloud Workflow to delete the Google Bucket objects"
+    parameter "approval_reason" do
+      type "string"
+      label "Reason for Approval"
+      description "Explain why you are approving the action."
+    end
+  end
+  run "delete_bucket_objects", data
+end
+
+###############################################################################
+# Cloud Workflow
+###############################################################################
+
+#https://cloud.google.com/storage/docs/json_api/v1/objects/copy
+define modify_bucket_object_storage_class($data) return $all_responses do
+  $$debug=true
+  call google_authenticate() retrieve $access_token
+  $all_responses = []
+  foreach $item in $data do
+    call url_encode($item['bucket_name']) retrieve $bucket_name
+    call url_encode($item['object_name']) retrieve $object_name
+    $response = http_request({
+                              verb: 'post',
+                              host: 'www.googleapis.com',
+                              href: join(['/storage/v1/b/', $bucket_name, '/o/', $object_name, '/rewriteTo/b/', $bucket_name, '/o/', $object_name]),
+                              https: true,
+                              body: {
+                                     "storageClass": $item['modify_storage_class_to']
+                                    },
+                              headers: {
+                                          "cache-control": "no-cache",
+                                          "content-type": "application/json",
+                                          "authorization": "Bearer " + $access_token
+                                          }
+                            })
+      $all_responses << $response
+      call sys_log('Google object storage optimization response ',to_s($response))
+  end
+end
+
+#https://cloud.google.com/storage/docs/json_api/v1/objects/delete
+define delete_bucket_objects($data) return $all_responses do
+  $$debug=true
+  call google_authenticate() retrieve $access_token
+  $all_responses = []
+  foreach $item in $data do
+    call url_encode($item['bucket_name']) retrieve $bucket_name
+    call url_encode($item['object_name']) retrieve $object_name
+    $response = http_request({
+                              verb: 'delete',
+                              host: 'www.googleapis.com',
+                              href: join(['/storage/v1/b/', $bucket_name, '/o/', $object_name]),
+                              https: true,
+                              headers: {
+                                          "cache-control": "no-cache",
+                                          "content-type": "application/json",
+                                          "authorization": "Bearer " + $access_token
+                                          }
+                            })
+      $all_responses << $response
+      call sys_log('Google Storage optimization delete response ',to_s($response))
+  end
+end
+
+
+define google_authenticate() return $access_token do
+  #The scope below only counts for devstorage, you will want to change to accomodate your needs. 
+  $jwt = {
+    iss: cred("GCE_PLUGIN_ACCOUNT"),
+    aud: "https://oauth2.googleapis.com/token",
+    exp: to_n(strftime(now()+3600, "%s")),
+    iat: to_n(strftime(now(), "%s")),
+    scope: "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/devstorage.read_only https://www.googleapis.com/auth/devstorage.full_control https://www.googleapis.com/auth/devstorage.read_write"
+  }
+
+  $signed_sigurature = jwt_encode("RS256", $jwt, cred("GCE_PLUGIN_PRIVATE_KEY"),{typ:"JWT"})
+
+  $response = http_request({
+    verb: 'post',
+    href: '/token',
+    host: 'oauth2.googleapis.com',
+    https: true,
+    headers: {
+      "content-type": "application/json"
+    },
+    body:{
+      "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      "assertion": $signed_sigurature
+    }
+  })
+  $access_token = $response["body"]["access_token"]
+end
+
+define sys_log($subject, $detail) do
+  if $$debug
+    rs_cm.audit_entries.create(
+      notify: "None",
+      audit_entry: {
+        auditee_href: @@account,
+        summary: "Google Storage optimization Policy "+ $subject,
+        detail: $detail
+      }
+    )
+  end
+end
+
+define url_encode($string) return $encoded_string do
+  $encoded_string = $string
+  $encoded_string = gsub($encoded_string, " ", "%20")
+  $encoded_string = gsub($encoded_string, "!", "%21")
+  $encoded_string = gsub($encoded_string, "#", "%23")
+  $encoded_string = gsub($encoded_string, "$", "%24")
+  $encoded_string = gsub($encoded_string, "&", "%26")
+  $encoded_string = gsub($encoded_string, "'", "%27")
+  $encoded_string = gsub($encoded_string, "(", "%28")
+  $encoded_string = gsub($encoded_string, ")", "%29")
+  $encoded_string = gsub($encoded_string, "*", "%2A")
+  $encoded_string = gsub($encoded_string, "+", "%2B")
+  $encoded_string = gsub($encoded_string, ",", "%2C")
+  $encoded_string = gsub($encoded_string, "/", "%2F")
+  $encoded_string = gsub($encoded_string, ":", "%3A")
+  $encoded_string = gsub($encoded_string, ";", "%3B")
+  $encoded_string = gsub($encoded_string, "=", "%3D")
+  $encoded_string = gsub($encoded_string, "?", "%3F")
+  $encoded_string = gsub($encoded_string, "@", "%40")
+  $encoded_string = gsub($encoded_string, "[", "%5B")
+  $encoded_string = gsub($encoded_string, "]", "%5D")
+end

--- a/cost/google/object_storage_optimization/google_object_storage_optimization.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization.pt
@@ -175,7 +175,7 @@ script "js_google_filtered_bucket_objects", type: "javascript" do
         }
       }
 
-      if(isTagMatched && bucket_object.storage_class !== "nearline" && bucket_object.storage_class !== "coldline"){
+      if(!isTagMatched && (bucket_object.storage_class).toLowerCase() !== "nearline" && (bucket_object.storage_class).toLowerCase() !== "coldline"){
         var last_modified_date = (new Date(bucket_object["last_modified"])).setHours(23, 59, 59, 999);
         var modify_storage_class_to="";
         if(param_nearline_days.length > 0 && param_coldline_days.length == 0 &&  last_modified_date <= nearline_date){
@@ -205,7 +205,7 @@ script "js_google_filtered_bucket_objects", type: "javascript" do
             "creation_date": bucket_object["creation_date"],
             "region":bucket_object["region"],
             "object_name": bucket_object["object_name"],
-            "storage_class": bucket_object["storage_class"],
+            "storage_class": (bucket_object["storage_class"]).toLowerCase(),
             "last_modified": bucket_object["last_modified"],
             "modify_storage_class_to": modify_storage_class_to,
             "object_size": bucket_object["object_size"],


### PR DESCRIPTION
### Description

This Policy checks Google buckets for older objects and can move the old object to 'nearline' or 'coldline' after a given period of time. The user can choose to delete the old object by enabling 'delete action' option as mentioned in Enable delete action section below.

### Issues Resolved

- This policy identifies all Google storage objects last updated outside of the specified timeframe
- For all objects identified as old, the user can choose to move the object to 'nearline' or 'coldline' after the specified timeframe.
- The user can choose to delete the old object by enabling 'delete action' option as mentioned in Enable delete action section below.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD

### Running link

https://governance.rightscale.com/org/1105/projects/60073/policy-incidents/5d822e430178e60089acb7da

### Screenshot

![image](https://user-images.githubusercontent.com/47381949/65152621-f0428280-da45-11e9-9bee-ff2e8efb5ed1.png)

