### PR TITLE
POL-118 Update region datasources to use github data list

### DIFF
--- a/cost/aws/s3_bucket_size/CHANGELOG.md
+++ b/cost/aws/s3_bucket_size/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.1
+-----
+- Updated region datasources to use github data list
+
 v1.0
 -----
 - initial release

--- a/cost/aws/s3_bucket_size/aws_bucket_size.pt
+++ b/cost/aws/s3_bucket_size/aws_bucket_size.pt
@@ -2,7 +2,7 @@ name "AWS Bucket Size Check"
 rs_pt_ver 20180301
 type "policy"
 short_description "This Policy Template scans all S3 buckets in the given account and checks if the bucket exceeds a specified byte size. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/aws/s3_bucket_size) and [docs.rightscale.com/policies] (http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.1"
+long_description "Version: 1.2"
 severity "medium"
 category "Cost"
 

--- a/cost/aws/s3_bucket_size/aws_bucket_size.pt
+++ b/cost/aws/s3_bucket_size/aws_bucket_size.pt
@@ -2,7 +2,7 @@ name "AWS Bucket Size Check"
 rs_pt_ver 20180301
 type "policy"
 short_description "This Policy Template scans all S3 buckets in the given account and checks if the bucket exceeds a specified byte size. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/aws/s3_bucket_size) and [docs.rightscale.com/policies] (http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.0"
+long_description "Version: 1.1"
 severity "medium"
 category "Cost"
 
@@ -98,8 +98,7 @@ for ( i = 0; i < buckets.length; i++ ) {
       "bucket_name": buckets[i]["bucket_name"],
       "creation_date": buckets[i]["creation_date"],
       "region": buckets[i]["region"],
-      "host": "s3-" + buckets[i]["region"] + ".amazonaws.com",
-      "auth": "s3_" + buckets[i]["region"].replace(/-/g,"_")
+      "host": "s3-" + buckets[i]["region"] + ".amazonaws.com"
     }
     )
   }

--- a/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
+++ b/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
@@ -2,7 +2,7 @@ name "AWS Publicly Accessible RDS Instances"
 rs_pt_ver 20180301
 type "policy"
 short_description "Report and remediate any Relational Database Service (RDS) instances that are publicly accessible. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_publicly_accessible) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.0"
+long_description "Version: 1.1"
 category "Security"
 severity "high"
 
@@ -59,9 +59,14 @@ end
 # Datasources
 ###############################################################################
 
-#Generates list of Regions.
+#Generates list of Regions
 datasource "ds_regions_list" do
-  run_script $js_regions_map
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/data/aws/regions.json"
+    header "User-Agent", "RS Policies"
+  end
 end
 
 #To get list of All RDS Instances.
@@ -125,31 +130,6 @@ end
 ###############################################################################
 # Scripts
 ###############################################################################
-
-script "js_regions_map", type: "javascript" do
-  result "regions_map"
-  code <<-EOS
-    var regions_map=[]
-    regions_map.push(
-      {"region": "us-east-1"},
-      {"region": "us-east-2"},
-      {"region": "us-west-1"},
-      {"region": "us-west-2"},
-      {"region": "ap-south-1"},
-      {"region": "ap-northeast-2"},
-      {"region": "ap-southeast-1"},
-      {"region": "ap-southeast-2"},
-      {"region": "ap-northeast-1"},
-      {"region": "ca-central-1"},
-      {"region": "eu-central-1"},
-      {"region": "eu-west-1"},
-      {"region": "eu-west-2"},
-      {"region": "eu-west-3"},
-      {"region": "sa-east-1"},
-      {"region": "eu-north-1"}
-    )
-  EOS
-end
 
 #https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html
 script "js_rds_list", type: "javascript" do

--- a/security/aws/rds_publicly_accessible/CHANGELOG.md
+++ b/security/aws/rds_publicly_accessible/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.1
+-----
+- Updated region datasources to use github data list
+
 v1.0
 -----
 - initial release

--- a/security/aws/rds_unencrypted/AWS_Unencrypted_RDS_Instances.pt
+++ b/security/aws/rds_unencrypted/AWS_Unencrypted_RDS_Instances.pt
@@ -2,7 +2,7 @@ name "AWS Unencrypted RDS Instances"
 rs_pt_ver 20180301
 type "policy"
 short_description "Report any Relational Database Service (RDS) instances that are unencrypted. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_unencrypted) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.0"
+long_description "Version: 1.1"
 category "Security"
 severity "medium"
 
@@ -59,9 +59,14 @@ end
 # Datasources
 ###############################################################################
 
-#Generates list of Regions.
+#Generates list of Regions
 datasource "ds_regions_list" do
-  run_script $js_regions_map
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/data/aws/regions.json"
+    header "User-Agent", "RS Policies"
+  end
 end
 
 #Get the list of All RDS Instances across all regions.
@@ -142,31 +147,6 @@ end
 ###############################################################################
 # Scripts
 ###############################################################################
-
-script "js_regions_map", type: "javascript" do
-  result "regions_map"
-  code <<-EOS
-    var regions_map=[]
-    regions_map.push(
-      {"region": "us-east-1"}, 
-      {"region": "us-east-2"}, 
-      {"region": "us-west-1"},
-      {"region": "us-west-2"},
-      {"region": "ap-south-1"},
-      {"region": "ap-northeast-2"},
-      {"region": "ap-southeast-1"},
-      {"region": "ap-southeast-2"},
-      {"region": "ap-northeast-1"},
-      {"region": "ca-central-1"},
-      {"region": "eu-central-1"},
-      {"region": "eu-west-1"},
-      {"region": "eu-west-2"},
-      {"region": "eu-west-3"},
-      {"region": "sa-east-1"},
-      {"region": "eu-north-1"}
-    )
-  EOS
-end
 
 #Process the response data, check for the tags and generate a list of unencrypted RDS instances
 script "js_rds_filter_map", type: "javascript" do

--- a/security/aws/rds_unencrypted/CHANGELOG.md
+++ b/security/aws/rds_unencrypted/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.1
+-----
+- Updated region datasources to use github data list
+
 v1.0
 -----
 - initial release

--- a/security/storage/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
+++ b/security/storage/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.2
+----
+- Updated region datasources to use github data list
+
 v1.1
 ----
 - Added Approval block

--- a/security/storage/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
+++ b/security/storage/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
@@ -2,7 +2,7 @@ name "AWS S3 Buckets without Server Access Logging"
 rs_pt_ver 20180301
 type "policy"
 short_description "Checks for buckets that do not have server_access_logging enabled. See the [README](https://github.com/rightscale/policy_templates/tree/master/security/storage/aws/s3_buckets_without_server_access_logging) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.1"
+long_description "Version: 1.2"
 severity "high"
 category "Security"
 
@@ -57,16 +57,6 @@ end
 ###############################################################################
 # Datasources
 ###############################################################################
-
-#Generates list of Regions
-datasource "ds_regions_list" do
-  request do
-    verb "GET"
-    host "raw.githubusercontent.com"
-    path "/rightscale/policy_templates/master/data/aws/regions.json"
-    header "User-Agent", "RS Policies"
-  end
-end
 
 # Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
 datasource "aws_buckets" do


### PR DESCRIPTION
Updated region datasources to use github data list

### Description

Identified AWS policies that used  hard coded list of regions and replaced it with the region list file in github.

### Issues Resolved
Referring Regions from github and removed datasource which we were not using internally. I tested policies and are working fine.

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
