### PR TITLE
AzureRM Subscription Access - Root Level Assignments

### DIFF
--- a/compliance/azure/subscription_access/CHANGELOG.md
+++ b/compliance/azure/subscription_access/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3
+
+- Added filter to only gather role assignments from the subscription level
+
 ## v1.2
 
 - Added pagination for the Microsoft Graph API users call

--- a/compliance/azure/subscription_access/README.md
+++ b/compliance/azure/subscription_access/README.md
@@ -7,7 +7,7 @@ This policy checks all users who have Owner or Contributor access to a given Azu
 ## Functional Details
 
 The policy leverages the Azure RBAC API to get all the users with the given role(s) on the given subscription.
-When the list of users that match the criteria changes, an incident is created and the details are reported via email. 
+When the list of users that match the criteria changes, an incident is created and the details are reported via email.
 
 ## Pre-requisites
 

--- a/compliance/azure/subscription_access/azure_subscription_access.pt
+++ b/compliance/azure/subscription_access/azure_subscription_access.pt
@@ -2,7 +2,7 @@ name "Azure Subscription Access"
 rs_pt_ver 20180301
 type "policy"
 short_description "Lists anyone who has been granted Owner or Contributor access to an Azure subscription. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/compliance/azure/subscription_access) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.2"
+long_description "Version: 1.3"
 category "Compliance"
 severity "low"
 
@@ -156,6 +156,7 @@ datasource "ds_azure_role_assignments" do
     host "management.azure.com"
     path join(["/subscriptions/", $param_azure_sub, "/providers/Microsoft.Authorization/roleAssignments"])
     query "api-version","2015-07-01"
+    query "$filter","atScope()"
     header "User-Agent", "RS Policies"
   end
   result do
@@ -199,9 +200,12 @@ script "js_filter_resources", type: "javascript" do
     // Iterate through all resources
     _.each(ds_filtered_azure_role_definitions, function(definition){
       var result = _.filter(ds_azure_role_assignments, function(ra) { return ra.properties.roleDefinitionId == definition.id})
+      console.log("Role Assignments:", result)
       _.each(result, function(r) {
+        console.log("result: " + r.id)
         var user = _.find(ds_azure_users, function(user){ return user.id == r.properties.principalId })
         if (user != null){
+          console.log("user: " + user.id + " " + user.userPrincipalName)
           results.push({
             name: user.displayName,
             username: user.mail,

--- a/compliance/azure/subscription_access/azure_subscription_access.pt
+++ b/compliance/azure/subscription_access/azure_subscription_access.pt
@@ -200,12 +200,9 @@ script "js_filter_resources", type: "javascript" do
     // Iterate through all resources
     _.each(ds_filtered_azure_role_definitions, function(definition){
       var result = _.filter(ds_azure_role_assignments, function(ra) { return ra.properties.roleDefinitionId == definition.id})
-      console.log("Role Assignments:", result)
       _.each(result, function(r) {
-        console.log("result: " + r.id)
         var user = _.find(ds_azure_users, function(user){ return user.id == r.properties.principalId })
         if (user != null){
-          console.log("user: " + user.id + " " + user.userPrincipalName)
           results.push({
             name: user.displayName,
             username: user.mail,


### PR DESCRIPTION
### Description

Adds a filter to the role assignment call to only gather assignments from the root of the subscription.

### Issues Resolved

n/a

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
