### PR TITLE
POL-26-AWS - Check for long-stopped instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Please contact sales@flexera.com to learn more.
 - [AWS Disallowed Regions](./compliance/aws/disallowed_regions/)
 - [AWS Unused ECS Clusters](./compliance/aws/ecs_unused/)
 - [AWS EC2 Instances not running FlexNet Inventory Agent](./compliance/aws/instances_without_fnm_agent/)
+- [AWS Long-stopped instances](./compliance/aws/long_stopped_instances/)
 
 #### Azure
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Please contact sales@flexera.com to learn more.
 - [AWS Disallowed Regions](./compliance/aws/disallowed_regions/)
 - [AWS Unused ECS Clusters](./compliance/aws/ecs_unused/)
 - [AWS EC2 Instances not running FlexNet Inventory Agent](./compliance/aws/instances_without_fnm_agent/)
-- [AWS Long-stopped instances](./compliance/aws/long_stopped_instances/)
+- [AWS Long-stopped Instances](./compliance/aws/long_stopped_instances/)
 
 #### Azure
 

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0
+
+- initial release

--- a/compliance/aws/long_stopped_instances/README.md
+++ b/compliance/aws/long_stopped_instances/README.md
@@ -1,0 +1,67 @@
+## Long-Stopped Instances
+
+### What it does
+
+This policy checks all instances that are stopped and reports on any that have been stopped for more than a specified period of time. The user is given the option to Terminate the instance after approval.
+
+### Functional Details
+
+The policy leverages the AWS API to check all instances that have been stopped for longer than the specified period. If the action is approved, the instance is terminated.
+
+### Input Parameters
+
+- *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created.
+- *Exclusion Tag* - List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'.
+- *Stopped days* - Number of days an instance is stopped before it is added to the report.
+
+### Actions
+
+- Sends an email notification.
+- Terminate reported instances after approval.
+
+### Cloud Management Required Permissions/AWS Required Permissions
+
+- Cloud Management - The `credential_viewer`, `policy_designer`, `policy_manager` & `policy_publisher` roles
+- AWS - The `CloudWatchReadOnlyAccess` AWS IAM Policy
+
+### AWS Required Permissions
+
+This policy requires permissions to describe AWS ECS DescribeInstances and Get Metric Statistics from the AWS Cloudwatch API.
+The Cloud Management Platform automatically creates two Credentials when connecting AWS to Cloud Management; AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. The IAM user credentials contained in those credentials will require the following permissions:
+
+```javascript
+{
+  "Version": "2016-11-15",
+  "Statement":[{
+  "Effect":"Allow",
+  "Action":["ec2: DescribeInstances"],
+    "Resource":"*"
+    }
+  ]
+}
+```
+
+```javascript
+{
+  "Version": "2012-10-17",
+  "Statement":[{
+      "Effect":"Allow",
+      "Action":["cloudwatch:GetMetricStatistics"],
+      "Resource":"*",
+      "Condition":{
+         "Bool":{
+            "aws:SecureTransport":"true"
+            }
+         }
+      }
+   ]
+}
+```
+
+### Supported Clouds
+
+- AWS
+
+### Cost
+
+This Policy Template does not incur any cloud costs.

--- a/compliance/aws/long_stopped_instances/README.md
+++ b/compliance/aws/long_stopped_instances/README.md
@@ -43,7 +43,7 @@ The Cloud Management Platform automatically creates two Credentials when connect
 
 ```javascript
 {
-  "Version": "2012-10-17",
+  "Version": "2010-08-01",
   "Statement":[{
       "Effect":"Allow",
       "Action":["cloudwatch:GetMetricStatistics"],

--- a/compliance/aws/long_stopped_instances/README.md
+++ b/compliance/aws/long_stopped_instances/README.md
@@ -1,10 +1,10 @@
-## Long-Stopped Instances
+# AWS Long-Stopped Instances
 
-### What it does
+## What it does
 
 This policy checks all instances that are stopped and reports on any that have been stopped for more than a specified period of time. The user is given the option to Terminate the instance after approval.
 
-### Functional Details
+## Functional Details
 
 The policy leverages the AWS API to check all instances that have been stopped for longer than the specified period. If the action is approved, the instance is terminated.
 

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -1,0 +1,301 @@
+name "AWS Long-stopped instances"
+rs_pt_ver 20180301
+type "policy"
+short_description "Report on any instances that have been stopped for a long time with the option to Terminate them. \n See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/aws/long_stopped_instances) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
+long_description "Version: 1.0"
+category "Compliance"
+severity "low"
+
+###############################################################################
+# Permissions
+###############################################################################
+
+permission "perm_read_creds" do
+  actions   "rs_cm.show_sensitive","rs_cm.index_sensitive"
+  resources "rs_cm.credentials"
+end
+
+###############################################################################
+# User inputs
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created."
+end
+
+parameter "param_exclude_tags" do
+  type "list"
+  category "User Inputs"
+  label "Exclusion Tag"
+  description "List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'."
+end
+
+parameter "param_stopped_days" do
+  type "number"
+  label "Stopped days"
+  description "Number of days an instance is stopped before it is added to the report."
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+auth "auth_aws", type: "aws" do
+  version 4
+  service "ec2"
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "monitoring_auth_aws", type: "aws" do
+  version 4
+  service "monitoring"
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "aws_pagination_xml" do
+  get_page_marker do
+    body_path "//DescribeInstancesResponse/nextToken"
+  end
+  set_page_marker do
+    query "NextToken"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+#Generates list of Regions
+datasource "ds_regions_list" do
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/data/aws/regions.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+#Get the list of all EC2 Instances across all regions.
+#https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
+datasource "ds_ec2_stopped_instances_list" do
+  iterate $ds_regions_list
+  request do
+    auth $auth_aws
+    pagination $aws_pagination_xml
+    verb "GET"
+    host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
+    path "/"
+    query "Action", "DescribeInstances"
+    query "Version", "2016-11-15"
+    query "Filter.1.Name", "instance-state-name"
+    query "Filter.1.Value.1", "stopped"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//DescribeInstancesResponse/reservationSet/item/instancesSet/item","array") do
+      field "instance_id", xpath(col_item, "instanceId")
+      field "region", val(iter_item,"region")
+      field "instance_state", xpath(col_item, "instanceState/name")
+      field "instance_type", xpath(col_item,"instanceType")
+      field "tags" do
+        collect xpath(col_item, "tagSet/item") do
+          field "tagKey", xpath(col_item, "key")
+          field "tagValue", xpath(col_item, "value")
+        end
+      end
+    end
+  end
+end
+
+datasource "ds_cloudwatch_cpu_usage" do
+  iterate $ds_ec2_stopped_instances_list
+  request do
+    run_script $js_cloudwatch_cpu_usage, $param_stopped_days, val(iter_item, "region"), val(iter_item, "instance_id")
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "GetMetricStatisticsResponse.GetMetricStatisticsResult") do
+      field "instance_id", val(iter_item, "instance_id") 
+      field "datapoints", jmes_path(col_item,"Datapoints")
+    end
+  end
+end
+
+datasource "ds_list_aws_instances" do
+  run_script $js_filter_aws_instances, $ds_ec2_stopped_instances_list, $ds_cloudwatch_cpu_usage, $param_exclude_tags
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+#https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricStatistics.html
+script "js_cloudwatch_cpu_usage", type: "javascript" do
+  result "results"
+  parameters "param_stopped_days","region","instance_id"
+  code <<-EOS
+  var start_date = new Date(new Date().setDate(new Date().getDate() - parseInt(param_stopped_days))).toISOString();
+  console.log("start_date = " + start_date);
+  var end_date = new Date().toISOString();
+  console.log("end_date = " + end_date);
+  results = {
+    "auth": "monitoring_auth_aws",
+    "host": 'monitoring.'+region+'.amazonaws.com',
+    "verb": "GET",
+    "path": "/",
+    "headers": {
+      "User-Agent": "RS Policies",
+      "Content-Type": "application/json",
+      "x-amz-target": "GraniteServiceVersion20100801.GetMetricStatistics",
+      "Accept": "application/json",
+      "Content-Encoding": "amz-1.0"
+    }
+    "query_params": {
+      'Action': 'GetMetricStatistics',
+      'Version': '2010-08-01',
+      'Namespace': 'AWS/EC2',
+      'MetricName': 'CPUUtilization',
+      'Dimensions.member.1.Name': 'InstanceId',
+      'Dimensions.member.1.Value': instance_id,
+      'StartTime': start_date,
+      'EndTime': end_date,
+      'Period': "2592000",
+      'Statistics.member.1': 'Maximum',
+      'Statistics.member.2': 'Average',
+      'Statistics.member.3': 'Minimum'
+    }
+  }
+EOS
+end
+
+script "js_filter_aws_instances", type: "javascript" do
+  parameters "ds_ec2_stopped_instances_list", "ds_cloudwatch_cpu_usage", "param_exclude_tags"
+  result "res"
+  code <<-EOS
+   res = []
+   var param_exclude_tags_lower=[];
+    for(var i=0; i < param_exclude_tags.length; i++){
+      param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
+    }
+    _.each(ds_ec2_stopped_instances_list, function(instance_stopped){
+      _.each(ds_cloudwatch_cpu_usage, function(cloudwatch_metrics){	  
+        var tags=instance_stopped['tags'];
+        var is_tag_matched=false
+        var tag_key_value=""
+        if(typeof(tags) != "undefined"){
+	      for(var k=0;k<tags.length;k++){
+            var tag=tags[k];
+            if((param_exclude_tags_lower.indexOf((tag['tagKey']).toLowerCase()) !== -1) ||      (param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1)){
+                is_tag_matched = true;
+            }
+            // Constructing tags with comma separated to display in detail_template
+            if((tag['tagValue']).length > 0){
+              tag_key_value = tag_key_value + ', '+ tag['tagKey']+'='+tag['tagValue']
+            }else{
+              tag_key_value = tag_key_value + ', '+ tag['tagKey']
+            }
+		  }
+        }
+	    //If the EC2 instance tag does not match with entered param_exclude_tags and cloud metrics is empty,
+		if(instance_stopped["instance_id"] == cloudwatch_metrics["instance_id"] && cloudwatch_metrics['datapoints'].length == 0 && !is_tag_matched){
+          res.push({
+            instance_id: instance_stopped['instance_id'],
+            region: instance_stopped['region'],
+            tagKeyValue:(tag_key_value.slice(1)),
+            instance_state: instance_stopped['instance_state'],
+            instance_type: instance_stopped['instance_type']
+          })
+        }
+      })
+	})
+		
+  EOS
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_report_stopped_instances" do
+  email $param_email
+end
+
+escalation "esc_terminate_stopped_instances" do
+  request_approval  do
+    label "Approve Termination of Long-stopped Instances"
+    description "Approve escalation to run RightScale Cloud Workflow to terminate long stopped AWS instances"
+    parameter "approval_reason" do
+      type "string"
+      label "Reason for Approval"
+      description "Explain why you are approving the action"
+    end
+  end
+  run "terminate_instances", data
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_list_aws_instances" do
+  validate $ds_list_aws_instances do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} AWS Instances Stopped for Over {{parameters.param_stopped_days}} Day(s)"
+    detail_template <<-EOS
+# AWS Instance Details
+| Instance ID | State | Region | Instance Type | Tags |
+| ----------- | ----- | ------ | ------------- | ---- |
+{{ range data -}}
+| {{.instance_id}} | {{.instance_state}}  | {{.region}} | {{.instance_type}} | {{.tagKeyValue}} |
+{{ end -}}
+___
+###### Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})
+EOS
+    escalate $esc_report_stopped_instances
+    escalate $esc_terminate_stopped_instances
+    check eq(size(data),0)
+  end
+end
+
+###############################################################################
+# Cloud Workflow
+###############################################################################
+
+#https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TerminateInstances.html
+define terminate_instances($data) return $all_responses do
+  $$debug=true
+  $all_responses = []
+  foreach $item in $data do
+   sub on_error: skip do
+    $response = http_get(
+       url: "https://ec2."+$item["region"]+".amazonaws.com/?Action=TerminateInstances&Version=2016-11-15&InstanceId.1="+$item["instance_id"],
+       "signature": { type: "aws",
+                      "access_key": cred("AWS_ACCESS_KEY_ID"),
+                      "secret_key": cred("AWS_SECRET_ACCESS_KEY") 
+	                }
+    )
+    $all_responses << $response
+    call sys_log('terminate long stopped ec2 instances response',to_s($response))
+    end
+  end
+end
+
+define sys_log($subject, $detail) do
+  if $$debug
+    rs_cm.audit_entries.create(
+      notify: "None",
+      audit_entry: {
+        auditee_href: @@account,
+        summary: "AWS Long stopped Instances Policy "+ $subject,
+        detail: $detail
+      }
+    )
+  end
+end

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -1,4 +1,4 @@
-name "AWS Long-stopped instances"
+name "AWS Long-stopped Instances"
 rs_pt_ver 20180301
 type "policy"
 short_description "Report on any instances that have been stopped for a long time with the option to Terminate them. \n See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/aws/long_stopped_instances) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
@@ -250,10 +250,10 @@ policy "pol_list_aws_instances" do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} AWS Instances Stopped for Over {{parameters.param_stopped_days}} Day(s)"
     detail_template <<-EOS
 # AWS Instance Details
-| Instance ID | State | Region | Instance Type | Tags |
-| ----------- | ----- | ------ | ------------- | ---- |
+| Instance ID | Region | Instance Type | Tags |
+| ----------- | ------ | ------------- | ---- |
 {{ range data -}}
-| {{.instance_id}} | {{.instance_state}}  | {{.region}} | {{.instance_type}} | {{.tagKeyValue}} |
+| {{.instance_id}} | {{.region}} | {{.instance_type}} | {{.tagKeyValue}} |
 {{ end -}}
 ___
 ###### Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -83,10 +83,14 @@ datasource "ds_regions_list" do
   end
 end
 
+datasource "ds_sorted_region_list" do
+  run_script $js_sorted_region, $ds_regions_list
+end
+
 #Get the list of all EC2 Instances across all regions.
 #https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
 datasource "ds_ec2_stopped_instances_list" do
-  iterate $ds_regions_list
+  iterate $ds_sorted_region_list
   request do
     auth $auth_aws
     pagination $aws_pagination_xml
@@ -136,6 +140,28 @@ end
 ###############################################################################
 # Scripts
 ###############################################################################
+
+script "js_sorted_region", type: "javascript" do
+  result "sorted_region"
+  parameters "ds_regions_list"
+  code <<-EOS
+  var sorted_region=[];
+  _.each(ds_regions_list, function(region){
+    sorted_region.push(region);
+  })
+  sorted_region.sort(getSortOrder("region"));
+  function getSortOrder(prop){  
+    return function(a, b){  
+        if (a[prop] > b[prop]){  
+            return 1;  
+        } else if (a[prop] < b[prop]){  
+            return -1;  
+        }  
+        return 0; 
+    }  
+}
+EOS
+end
 
 #https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricStatistics.html
 script "js_cloudwatch_cpu_usage", type: "javascript" do


### PR DESCRIPTION
POL-26-AWS - Check for long-stopped instances

### Description

Check for instances that have been stopped for a long time.

### Issues Resolved

Terminate AWS instances that are stopped for a long time.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD

Running Link:
https://governance.rightscale.com/org/1105/projects/60073/policy-incidents/5dcbe0813202b80001bc4c4d

![AWS_Long_stopped_instances](https://user-images.githubusercontent.com/55177748/68758824-87861980-0634-11ea-8d77-49ee48dff50e.PNG)

