### PR TITLE
Fix budget alert timestamp

### DIFF
--- a/cost/budget_alerts/CHANGELOG.md
+++ b/cost/budget_alerts/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.5
+----
+- handling transition next month when in Dec -> January
+
 v1.4
 ----
 - Added tenancy "single" in metadata

--- a/cost/budget_alerts/budget_alert.pt
+++ b/cost/budget_alerts/budget_alert.pt
@@ -2,7 +2,7 @@ name "Budget Alerts"
 rs_pt_ver 20180301
 type "policy"
 short_description "Create a Monthly Budget Alert for a Billing Center or for the entire Organization. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/budget_alerts/) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.4"
+long_description "Version: 1.5"
 severity "medium"
 category "Cost"
 tenancy "single"
@@ -100,6 +100,11 @@ script "costs_request", type: "javascript" do
     if (month == 1){ 
       var lmonth = 12;
       var lyear = year-1 ;
+    }  else if (month == 13){
+      month = 1
+      var lmonth = 12;
+      var lyear = year
+      var year = year+1
     } else {
       var lmonth = month-1;
       var lyear = year ;


### PR DESCRIPTION
### Description
There's an issue when generating the next month.
While in December (12) , the next_month gets calculated as 13, instead of 1 and they year is also not updated.
[Describe what this change achieves]
Allows for budgets to be calculated between years.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
