### PR TITLE
POL-176-AWS-S3-Buckets-without-Server-Access-Login

### DIFF
--- a/security/storage/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
+++ b/security/storage/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
@@ -1,11 +1,18 @@
-v1.2
-----
+# Changelog
+
+## v2.0
+
+- Changes to support the Credential Service
+- Changed http method to PUT for define enable_logging.
+
+## v1.2
+
 - Updated region datasources to use github data list
 
-v1.1
-----
+## v1.1
+
 - Added Approval block
 
-v1.0
------
+## v1.0
+
 - Initial Release

--- a/security/storage/aws/s3_buckets_without_server_access_logging/README.md
+++ b/security/storage/aws/s3_buckets_without_server_access_logging/README.md
@@ -5,11 +5,13 @@
 This policy checks for any S3 buckets that don't have Server Access logging enabled and allows the user to enable logging after approval.
 
 ## Functional Details
+
 The policy leverages the AWS S3 API to find all buckets and check for any that don't have Server access logging enabled. Optionally, after approval, the policy can configure logging on any S3 bucket.  Use the Target Bucket input parameter to configure logging to an existing bucket.  If you Target Bucket is left blank a new bucket is creating using the source bucket name as the prefix and logging as the suffix, i.e. mybucket-logging
 
 *Note:* Logs can only be written to buckets in the same region, if this policy errors on setting the logging attribute, it will skip. You need 1 policy and bucket for every region.
 
 ## Input Parameters
+
 - *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
 - *Target Bucket* - An existing bucket in same reason as source to be used for logging.
 - *Target Bucket Prefix* - If using a Target Bucket, this element lets you specify a prefix for the keys that the log files will be stored under.
@@ -21,6 +23,7 @@ The following policy actions are taken on any resources found to be out of compl
 
 - Send an email report
 - Enable Server Access logging after approval.
+
 *Note:* Logs can only be written to buckets in the same region, if this policy errors on setting the logging attribute, it will skip. You need 1 policy and bucket for every region.
 
 ## Prerequisites

--- a/security/storage/aws/s3_buckets_without_server_access_logging/README.md
+++ b/security/storage/aws/s3_buckets_without_server_access_logging/README.md
@@ -1,27 +1,39 @@
-## AWS S3 Buckets without Server Access Logging
+# AWS S3 Buckets without Server Access Logging
 
-### What it does
+## What it does
 
 This policy checks for any S3 buckets that don't have Server Access logging enabled and allows the user to enable logging after approval.
 
-### Functional Details
+## Functional Details
 The policy leverages the AWS S3 API to find all buckets and check for any that don't have Server access logging enabled. Optionally, after approval, the policy can configure logging on any S3 bucket.  Use the Target Bucket input parameter to configure logging to an existing bucket.  If you Target Bucket is left blank a new bucket is creating using the source bucket name as the prefix and logging as the suffix, i.e. mybucket-logging
 
-*Note:* Logs can only be written to buckets in the same region, if this policy errors on setting the logging attribute, it will skip. You need 1 policy and bucket for every region. 
+*Note:* Logs can only be written to buckets in the same region, if this policy errors on setting the logging attribute, it will skip. You need 1 policy and bucket for every region.
 
-#### Input Parameters
+## Input Parameters
 - *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
-- *Target Bucket* - An existing bucket in same reason as source to be used for logging.  
+- *Target Bucket* - An existing bucket in same reason as source to be used for logging.
 - *Target Bucket Prefix* - If using a Target Bucket, this element lets you specify a prefix for the keys that the log files will be stored under.
-- *Exclude Target Bucket* - Exclude target bucket as additional fees may incur. 
+- *Exclude Target Bucket* - Exclude target bucket as additional fees may incur.
 
-### Required RightScale Roles
-- credential_viewer or admin
+## Policy Actions
 
-### AWS Required Permissions
+The following policy actions are taken on any resources found to be out of compliance.
 
-This policy requires permissions to describe AWS Buckets, and to Get/Put bucket logging options.
-The Cloud Management Platform automatically creates two Credentials when connecting AWS to Cloud Management; AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. The IAM user credentials contained in those credentials will require the following permissions:
+- Send an email report
+- Enable Server Access logging after approval.
+*Note:* Logs can only be written to buckets in the same region, if this policy errors on setting the logging attribute, it will skip. You need 1 policy and bucket for every region.
+
+## Prerequisites
+
+This policy uses [credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+
+### Credential configuration
+
+For administrators [creating and managing credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) to use with this policy, the following information is needed:
+
+Provider tag value to match this policy: `aws`
+
+Required permissions in the provider:
 
 ```javascript
 {
@@ -41,8 +53,10 @@ The Cloud Management Platform automatically creates two Credentials when connect
 }
 ```
 
-### Supported Clouds
+## Supported Clouds
+
 - AWS
 
-### Cost
+## Cost
+
 This Policy Template does not incur any cloud costs.

--- a/security/storage/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
+++ b/security/storage/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
@@ -1,10 +1,16 @@
 name "AWS S3 Buckets without Server Access Logging"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for buckets that do not have server_access_logging enabled. See the [README](https://github.com/rightscale/policy_templates/tree/master/security/storage/aws/s3_buckets_without_server_access_logging) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.2"
+short_description "Checks for buckets that do not have server_access_logging enabled. See the [README](https://github.com/flexera/policy_templates/tree/master/security/storage/aws/s3_buckets_without_server_access_logging) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+long_description ""
 severity "high"
 category "Security"
+info(
+  version: "2.0",
+  provider: "AWS",
+  service: "S3",
+  policy_set: ""
+  )
 
 ###############################################################################
 # Permissions
@@ -27,7 +33,7 @@ end
 parameter "param_target_bucket" do
   type "string"
   label "Target Bucket"
-  description "An existing bucket in same reason as source to be used for logging."
+  description "An existing bucket in same region as source to be used for logging."
 end
 
 parameter "param_target_prefix" do
@@ -47,11 +53,12 @@ end
 # Authentication
 ###############################################################################
 
-auth "auth_aws", type: "aws" do
-  version 4
-  service "s3"
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
+#authenticate with AWS
+credentials "auth_aws" do
+  schemes "aws","aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list."
+  tags "provider=aws"
 end
 
 ###############################################################################
@@ -142,6 +149,7 @@ datasource "aws_bucket_logging" do
     field "creation_date", val(iter_item,"creation_date")
     field "region", val(iter_item,"region")
     field "target_bucket", xpath(response,"//TargetBucket")
+    field "host",val(iter_item, "host")
   end
 end
 
@@ -222,12 +230,13 @@ define enable_logging($data, $param_target_bucket, $param_target_prefix) return 
     else
       $target_prefix = $param_target_prefix
     end
-    sub on_error: skip do
+
       $response = http_request(
-        verb: "post",
-        host: $item["bucket_name"]+".s3.amazonaws.com",
+        verb: "put",
+        host: $item["bucket_name"]+"."+$item["host"],
         https: true,
-        signature: { type: "aws", version: 4 },
+        auth: $$auth_aws,
+		href: "/",
         headers: {
           "content-type": "application/xml"
         },
@@ -236,7 +245,7 @@ define enable_logging($data, $param_target_bucket, $param_target_prefix) return 
       )
       $all_responses << $response
       call sys_log('all_responses', to_s($all_responses))
-    end
+
   end
 end
 


### PR DESCRIPTION
Fix for bug POL-176

### Description

This policy checks for any S3 buckets that don't have Server Access logging enabled and allows the user to enable logging after approval.

### Issues Resolved

- Changes to support the Credential Service
- Changed Http method to PUT for define enable_logging.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD

### Running template link and Screenshot

https://governance.rightscale.com/org/1105/projects/60073/policy-incidents/5e2967bf4ec7b300014e6b55
![image](https://user-images.githubusercontent.com/47381949/73010202-f901f580-3e37-11ea-8ed7-5bd49d16cea7.png)
