### PR TITLE
SRE1-194_add_exclude_org_id_parameter_to_master_org_cost_policy

### DIFF
--- a/msp/cost/master_org_cost_policy/CHANGELOG.md
+++ b/msp/cost/master_org_cost_policy/CHANGELOG.md
@@ -1,7 +1,9 @@
-v1.0
-----
-- Initial Release
+# Changelog
 
-v1.1
-----
+## v1.1
+
 - Exclude Orgs by ID added.
+
+## v1.0
+
+- Initial Release.

--- a/msp/cost/master_org_cost_policy/CHANGELOG.md
+++ b/msp/cost/master_org_cost_policy/CHANGELOG.md
@@ -1,3 +1,7 @@
 v1.0
 ----
 - Initial Release
+
+v1.1
+----
+- Exclude Orgs by ID added.

--- a/msp/cost/master_org_cost_policy/README.md
+++ b/msp/cost/master_org_cost_policy/README.md
@@ -16,6 +16,7 @@ We recommend running this policy on a weekly cadence and applying it to your mas
 
 _Note 1: The last 3 days of data in the current week or month will contain incomplete data._  
 _Note 2: The account you apply the policy to is unimportant as Optima metrics are scoped to the Org._
+_Note 3: If it excluding orgs is needed use only either 'Excluded Organizations' or 'Exclucded organizations IDs' parameter, not both._
 
 ## Cost Metrics
 

--- a/msp/cost/master_org_cost_policy/README.md
+++ b/msp/cost/master_org_cost_policy/README.md
@@ -4,17 +4,17 @@
 
 This policy allows you to set up cross organization scheduled reports that will provide summaries of cloud cost across all resources in the billing centers you specify, delivered to any email addresses you specify. The policy will report the following:
 
-Chart of the previous 6 months of utilization based on whichever [Reporting Dimension](https://docs.rightscale.com/optima/reference/rightscale_dimensions.html) you select (only bill data and RightScale-generated dimensions are supported).  
+Chart of the previous 6 months of utilization based on whichever [Reporting Dimension](https://docs.rightscale.com/optima/reference/rightscale_dimensions.html) you select (only bill data and RightScale-generated dimensions are supported).
 Daily Average - Weekly: Daily average costs calculated from Monday of the previous week through today.
 Daily Average - Monthly: Daily average costs calculated from the 1st of the previous month through today.
-Previous - Weekly: Total costs during previous full week (Monday-Sunday).  
-Previous - Monthly: Total costs during previous full month.  
-Current - Weekly: Total costs during current (incomplete) week.  
-Current - Monthly: Total costs during current (incomplete) month.  
+Previous - Weekly: Total costs during previous full week (Monday-Sunday).
+Previous - Monthly: Total costs during previous full month.
+Current - Weekly: Total costs during current (incomplete) week.
+Current - Monthly: Total costs during current (incomplete) month.
 
 We recommend running this policy on a weekly cadence and applying it to your master account.
 
-_Note 1: The last 3 days of data in the current week or month will contain incomplete data._  
+_Note 1: The last 3 days of data in the current week or month will contain incomplete data._
 _Note 2: The account you apply the policy to is unimportant as Optima metrics are scoped to the Org._
 _Note 3: If it excluding orgs is needed use only either 'Excluded Organizations' or 'Exclucded organizations IDs' parameter, not both._
 

--- a/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
+++ b/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
@@ -3,17 +3,23 @@ rs_pt_ver 20180301
 type "policy"
 short_description "This policy allows you to set up cross organization scheduled reports that will provide summaries of cloud cost across all resources in the billing centers you specify, delivered to any email addresses you specify. The policy will report the following:
 Chart of the previous 6 months of utilization based on [category](https://docs.rightscale.com/optima/reference/rightscale_dimensions.html#category).  
-Daily average cost across the last week and last month.  
-Total cost during previous full week (Monday-Sunday) and previous full month.  
-Total cost during current (incomplete) week and month.  
+Daily average cost across the last week and last month.
+Total cost during previous full week (Monday-Sunday) and previous full month.
+Total cost during current (incomplete) week and month.
 We recommend running this policy on a weekly cadence and applying it to your master account.
-_Note 1: The last 3 days of data in the current week or month will contain incomplete data._  
+_Note 1: The last 3 days of data in the current week or month will contain incomplete data._
 _Note 2: The account you apply the policy to is unimportant as Optima metrics are scoped to the Org._
-_Note 3: If it excluding orgs is needed use only either 'Excluded Organizations' or 'Exclucded organizations IDs' parameter, not both._
+_Note 3: If excluding orgs is needed use only either 'Excluded Organizations' or 'Exclucded organizations IDs' parameter, not both._
 See [README](https://github.com/rightscale/policy_templates/tree/master/msp/cost/master_org_cost_policy) for more details"
 long_description "Version: 1.1"
 severity "low"
 category "Cost"
+info(
+  version: "1.1",
+  provider: "Flexera Optima",
+  service: "",
+  policy_set: ""
+)
 
 ###############################################################################
 # Permissions

--- a/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
+++ b/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
@@ -9,8 +9,9 @@ Total cost during current (incomplete) week and month.
 We recommend running this policy on a weekly cadence and applying it to your master account.
 _Note 1: The last 3 days of data in the current week or month will contain incomplete data._  
 _Note 2: The account you apply the policy to is unimportant as Optima metrics are scoped to the Org._
+_Note 3: If it excluding orgs is needed use only either 'Excluded Organizations' or 'Exclucded organizations IDs' parameter, not both._
 See [README](https://github.com/rightscale/policy_templates/tree/master/msp/cost/master_org_cost_policy) for more details"
-long_description "Version: 1.0"
+long_description "Version: 1.1"
 severity "low"
 category "Cost"
 
@@ -30,7 +31,15 @@ end
 parameter "param_exclude_organizations" do
   type "list"
   label "Excluded Organizations"
-  description "Names of organizations to exclude"
+  description "Names of organizations to exclude. \n
+  NOTE: use only either 'Excluded Organizations' or 'Exclucded organizations IDs', not both"
+end
+
+parameter "param_exclude_organizations_ids" do
+  type "list"
+  label "Excluded Organizations IDs"
+  description "IDs of organizations to exclude. \n
+  NOTE: use only either 'Excluded Organizations' or 'Exclucded organizations IDs', not both"
 end
 
 parameter "param_cost_metric" do
@@ -92,7 +101,7 @@ datasource "ds_current_user_organizations" do
 end
 
 datasource "ds_filtered_user_organizations" do
-  run_script $js_filter_organizations, $ds_current_user_organizations, $param_exclude_organizations
+  run_script $js_filter_organizations, $ds_current_user_organizations, $param_exclude_organizations, $param_exclude_organizations_ids
 end
 
 datasource "ds_currency_reference" do
@@ -211,12 +220,18 @@ script "js_current_user_organizations", type: "javascript" do
 end
 
 script "js_filter_organizations", type: "javascript" do
-  parameters "ds_current_user_organizations", "param_exclude_organizations"
+  parameters "ds_current_user_organizations", "param_exclude_organizations", "param_exclude_organizations_ids"
   result "results"
   code <<-EOF
+  if ( param_exclude_organizations.length > 0) {
     var results = _.reject(ds_current_user_organizations, function(org){
-       return _.contains(param_exclude_organizations, org["name"])
+      return _.contains(param_exclude_organizations, org["name"])
     })
+  } else if ( param_exclude_organizations_ids.length > 0) {
+    var results = _.reject(ds_current_user_organizations, function(org){
+      return _.contains(param_exclude_organizations_ids, org["org_id"])
+    })
+  }
   EOF
 end
 


### PR DESCRIPTION
### Description

Some users have access to hundreds of orgs, so the org exclude list can be quite big as well. This PR adds a new optional parameter, param_exclude_organizations_ids which has the same functionality as param_exclude_organizations just that using org id's instead of org names.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD

![image](https://user-images.githubusercontent.com/2909726/73160561-9df72980-40e9-11ea-996f-37e4e346cd1f.png)


![image](https://user-images.githubusercontent.com/2909726/73160571-a64f6480-40e9-11ea-8faa-5d12575a26e6.png)

