### PR TITLE
SRE1-668_fix_excudled_orgs_js

### DIFF
--- a/msp/cost/master_org_cost_policy/CHANGELOG.md
+++ b/msp/cost/master_org_cost_policy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2
+
+- Fix case when no exclude parameter is used
+
 ## v1.1
 
 - Exclude Orgs by ID added.

--- a/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
+++ b/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
@@ -543,52 +543,68 @@ script "js_report", type: "javascript" do
     }
     var metric = cost_metric[param_cost_metric]
     var current_week_total = 0.00
+    console.log("current_week")
     _.each(ds_current_week_costs, function(item) {
       console.log(item)
-      for (var i = 0; i < item['rows'].length; i++) {
-        var row = item['rows'][i]
-        current_week_total += row['metrics'][metric]
+      if (item['rows'] != null && item['rows'] !== undefined){
+        for (var i = 0; i < item['rows'].length; i++) {
+          var row = item['rows'][i]
+          current_week_total += row['metrics'][metric]
+        }
       }
     })
 
+    console.log("previous_week")
     var previous_week_total = 0.00
     _.each(ds_previous_week_costs, function(item){
-      for (var i = 0; i < item['rows'].length; i++) {
-        var row = item['rows'][i]
-        previous_week_total += row['metrics'][metric]
+      if (item['rows'] != null && item['rows'] !== undefined){
+        for (var i = 0; i < item['rows'].length; i++) {
+          var row = item['rows'][i]
+          previous_week_total += row['metrics'][metric]
+        }
       }
     })
 
+    console.log("previous_month")
     var previous_month_total = 0.00
     _.each(ds_previous_month_costs, function(item){
-      for (var i = 0; i < item['rows'].length; i++) {
-        var row = item['rows'][i]
-        previous_month_total += row['metrics'][metric]
+      if (item['rows'] != null && item['rows'] !== undefined){
+        for (var i = 0; i < item['rows'].length; i++) {
+          var row = item['rows'][i]
+          previous_month_total += row['metrics'][metric]
+        }
       }
     })
 
+    console.log("current_month")
     var current_month_total = 0.00
     _.each(ds_current_month_costs, function(item){
-      for (var i = 0; i < item['rows'].length; i++) {
-        var row = item['rows'][i]
-        current_month_total += row['metrics'][metric]
+      if (item['rows'] != null && item['rows'] !== undefined){
+        for (var i = 0; i < item['rows'].length; i++) {
+          var row = item['rows'][i]
+          current_month_total += row['metrics'][metric]
+        }
       }
     })
 
     var weekly_avg = 0
     _.each(ds_current_week_costs,function(item){
-      if (item['rows'].length > 0){
-        var days_this_week = item['rows'].length
-        weekly_avg = (current_week_total + previous_week_total) / (7 + days_this_week)
+      if (item['rows'] != null && item['rows'] !== undefined){
+        if (item['rows'].length > 0){
+          var days_this_week = item['rows'].length
+          weekly_avg = (current_week_total + previous_week_total) / (7 + days_this_week)
+        }
       }
     })
 
     var monthly_avg = 0
     _.each(ds_current_month_costs,function(item){
-      if (item['rows'].length > 0){
-        var days_this_month = item['rows'].length
-        var days_last_month = item['rows'].length
-        monthly_avg = (current_month_total + previous_month_total) / ( days_last_month + days_this_month)
+      if (item['rows'] != null && item['rows'] !== undefined){
+        if (item['rows'].length > 0){
+          var days_this_month = item['rows'].length
+          var days_last_month = item['rows'].length
+          monthly_avg = (current_month_total + previous_month_total) / ( days_last_month + days_this_month)
+        }
       }
     })
 

--- a/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
+++ b/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
@@ -11,11 +11,11 @@ _Note 1: The last 3 days of data in the current week or month will contain incom
 _Note 2: The account you apply the policy to is unimportant as Optima metrics are scoped to the Org._
 _Note 3: If excluding orgs is needed use only either 'Excluded Organizations' or 'Exclucded organizations IDs' parameter, not both._
 See [README](https://github.com/rightscale/policy_templates/tree/master/msp/cost/master_org_cost_policy) for more details"
-long_description "Version: 1.1"
+long_description "Version: 1.2"
 severity "low"
 category "Cost"
 info(
-  version: "1.1",
+  version: "1.2",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""

--- a/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
+++ b/msp/cost/master_org_cost_policy/master_org_cost_policy.pt
@@ -229,11 +229,10 @@ script "js_filter_organizations", type: "javascript" do
   parameters "ds_current_user_organizations", "param_exclude_organizations", "param_exclude_organizations_ids"
   result "results"
   code <<-EOF
-  if ( param_exclude_organizations.length > 0) {
-    var results = _.reject(ds_current_user_organizations, function(org){
-      return _.contains(param_exclude_organizations, org["name"])
-    })
-  } else if ( param_exclude_organizations_ids.length > 0) {
+  var results = _.reject(ds_current_user_organizations, function(org){
+    return _.contains(param_exclude_organizations, org["name"])
+  })
+  if ( param_exclude_organizations_ids.length > 0) {
     var results = _.reject(ds_current_user_organizations, function(org){
       return _.contains(param_exclude_organizations_ids, org["org_id"])
     })


### PR DESCRIPTION
### Description
This will allow to use the policy without using any exclude parameters

### Issues Resolved
This pr fix the case when any of param_exclude_organizations or param_exclude_organizations_ids parameters are used.

### Contribution Check List

- [x ] All tests pass.
- [ x] New functionality includes testing.
- [x ] New functionality has been documented in the README if applicable
- [x ] New functionality has been documented in CHANGELOG.MD

Example of new case fixed:

https://governance.rightscale.com/org/1105/projects/60073/applied-policies/5e622efa5af98600017a5843

param_exclude_organizations=[]
param_exclude_organizations_ids=[] 

![image](https://user-images.githubusercontent.com/2909726/76082586-091b0200-5fac-11ea-9ae3-02bf75cd38f9.png)
