### PR TITLE
POL-227-Subscription Name is missing from Policies

### DIFF
--- a/cost/azure/idle_compute_instances/CHANGELOG.md
+++ b/cost/azure/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Changes to replicate Subscription Name in the final response
+
 ## v2.0
 
 - Changes to support the Credential Service

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -137,7 +137,7 @@ datasource "ds_azure_instance_performance" do
     field "location", val(iter_item, "location")
     field "tags", val(iter_item, "tags")
 	field "subscriptionId",val(iter_item,"subscriptionId")
-    field "subscriptionName",val(iter_item,"displayName")
+    field "subscriptionName",val(iter_item,"subscriptionName")
     field "averages" do
       collect jmes_path(response,"value[].data[]") do
         field "average", jmes_path(col_item,"average")

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Cost"
 severity "low"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle Compute Instances"


### PR DESCRIPTION
### Description

Subscription Name was not getting replicated in the final response from Azure Idle Compute Instances

### Issues Resolved

Subscription Name issue has been resolved

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD

Log link:
https://governance.rightscale.com/org/1105/projects/60073/applied-policies/5e6607e4daa77500017519f4