### PR TITLE
update auth tag

### DIFF
--- a/cost/azure/instances_log_analitics_utilization/CHANGELOG.md
+++ b/cost/azure/instances_log_analitics_utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4
+
+- adjusted Log Analytics auth provider tag
+
 ## v2.3
 
 - adding incident resource table

--- a/cost/azure/instances_log_analitics_utilization/azure_instance_log_analytics_utilization.pt
+++ b/cost/azure/instances_log_analitics_utilization/azure_instance_log_analytics_utilization.pt
@@ -6,7 +6,7 @@ long_description ""
 severity "low"
 category "Cost"
 info(
-  version: "2.3",
+  version: "2.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Inefficient Instance Usage"
@@ -64,7 +64,7 @@ credentials "log_analytics_auth" do
   schemes "oauth2"
   label "Azure Log Analytics"
   description "Select the Azure Resource Manager Credential for Log Analytics."
-  tags "provider=azure_rm"
+  tags "provider=azure_log"
 end
 
 


### PR DESCRIPTION
### Description

When a Log Analytics cred is created in cred manager, it has the provider tag `azure_log` set by default. The Instance Log Analytics policy is filtering by the `azure_rm` tag.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
