### PR TITLE
POL-307: Azure AD - Remove need for refresh token

### DIFF
--- a/operational/azure/azuread_group_sync/CHANGELOG.md
+++ b/operational/azure/azuread_group_sync/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Removed the need for a CMP refresh token
+
 ## v2.0
 
 - initial release

--- a/operational/azure/azuread_group_sync/README.md
+++ b/operational/azure/azuread_group_sync/README.md
@@ -38,6 +38,7 @@ You can elect to automatically remove users from your organization that are no l
 - A [configured Identity Provider](https://docs.rightscale.com/platform/guides/configuring_sso/) in the Cloud Management Platform.
 - [Groups need to be created](https://docs.rightscale.com/gov/getting_started/gov_groups.html), and have [permissions assigned](https://docs.rightscale.com/gov/getting_started/gov_groups.html#roles), for each one that you want to synchronize from AzureAD. This policy will NOT create groups, or assign permissions to them, in the CMP.
 - This policy uses [credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. [The information below](#Credential-Configuration) should be consulted when creating the credential.
+- The policy must be applied by a user with the `enterprise_manager` role.
 
 ### Credential Configuration
 
@@ -54,19 +55,6 @@ Resource: `Azure Active Directory`
 Required permissions in the provider:
 
 - Tenant > Azure Active Directory Graph > Directory.Read.All (Application with Admin Consent)
-
-### Credential #2
-
-Type: `Oauth2`  
-Grant Type: `Refresh Token`  
-Token URL: `https://us-3.rightscale.com/api/oauth2` or `https://us-4.rightscale.com/api/oauth2` (based on where token was generated)  
-Token: [Value of refresh token](https://docs.rightscale.com/cm/dashboard/settings/account/enable_oauth)  
-Additional Headers: `X-API-Version: 1.5`  
-Provider tag value to match this policy: `flexera_cmp`
-
-Required permissions in the provider:
-
-- enterprise_manager
 
 ## Supported Services
 

--- a/operational/azure/azuread_group_sync/azuread_group_sync.pt
+++ b/operational/azure/azuread_group_sync/azuread_group_sync.pt
@@ -8,7 +8,7 @@ severity "low"
 tenancy "single"
 default_frequency "hourly"
 info(
-    version: "2.0",
+    version: "2.1",
     provider: "Azure",
     service: "AzureAD"
 )
@@ -75,12 +75,7 @@ credentials "auth_azure_graph" do
   tags "provider=azure_graph"
 end
 
-credentials "auth_rs" do
-  schemes "oauth2"
-  label "Flexera CMP"
-  description "Select the CMP Credential from the list."
-  tags "provider=flexera_cmp"
-end
+auth "auth_rs", type: "rightscale"
 
 ###############################################################################
 # Pagination
@@ -420,7 +415,7 @@ policy "policy_azuread_group_sync" do
 {{ range data.groupsToCreate -}}
 <br />
 <br />
-### The following groups need to be created and have permissions assigned to them in Governance:
+### The following groups need to be created and have permissions assigned to them in [Governance](https://governance.rightscale.com/):
 {{ .name }}
 {{ end -}}
 {{ end -}}

--- a/operational/azure/azuread_group_sync/azuread_group_sync.pt
+++ b/operational/azure/azuread_group_sync/azuread_group_sync.pt
@@ -10,7 +10,8 @@ default_frequency "hourly"
 info(
     version: "2.1",
     provider: "Azure",
-    service: "AzureAD"
+    service: "AzureAD",
+    policy_set: ""
 )
 
 ###############################################################################


### PR DESCRIPTION
### Description

Enhancement to the policy to remove the need for a CMP refresh token and instead use inherited auth.

### Issues Resolved

N/A

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
