### PR TITLE
Fix sample IAM policy documents for AWS Unused Volumes

### DIFF
--- a/cost/aws/unused_volumes/README.md
+++ b/cost/aws/unused_volumes/README.md
@@ -41,31 +41,29 @@ The following AWS permissions must be allowed for the policy to run.
 ```json
 {
   "Version": "2012-10-17",
-  "Statement":[{
-    "Effect":"Allow",
-    "Action":[
-      "ec2:DescribeVolumes",
-      "ec2:CreateTags",
-      "ec2:CreateSnapshot",
-      "ec2:DescribeSnapshots",
-      "ec2:DeleteVolume"
-    ],
-    "Resource":"*"
-  }]
-}
-
-{
-  "Version": "2012-10-17",
-  "Statement":[{
-    "Effect":"Allow",
-    "Action":["cloudwatch:GetMetricStatistics"],
-    "Resource":"*",
-    "Condition":{
-      "Bool":{
-        "aws:SecureTransport":"true"
+  "Statement":[
+    {
+      "Effect":"Allow",
+      "Action":[
+        "ec2:DescribeVolumes",
+        "ec2:CreateTags",
+        "ec2:CreateSnapshot",
+        "ec2:DescribeSnapshots",
+        "ec2:DeleteVolume"
+      ],
+      "Resource":"*"
+    },
+    {
+      "Effect":"Allow",
+      "Action":["cloudwatch:GetMetricStatistics"],
+      "Resource":"*",
+      "Condition":{
+        "Bool":{
+          "aws:SecureTransport":"true"
+        }
       }
-     }
-  }]
+    }
+  ]
 }
 ```
 

--- a/cost/aws/unused_volumes/README.md
+++ b/cost/aws/unused_volumes/README.md
@@ -38,15 +38,20 @@ Provider tag value to match this policy: `aws`
 
 The following AWS permissions must be allowed for the policy to run.
 
-```javascript
+```json
 {
-    "Version": "2016-11-15",
-    "Statement":[{
+  "Version": "2012-10-17",
+  "Statement":[{
     "Effect":"Allow",
-    "Action":["ec2:DescribeVolumes","ec2:CreateTags","ec2:CreateSnapshot","ec2:DescribeSnapshots","ec2:DeleteVolume"],
+    "Action":[
+      "ec2:DescribeVolumes",
+      "ec2:CreateTags",
+      "ec2:CreateSnapshot",
+      "ec2:DescribeSnapshots",
+      "ec2:DeleteVolume"
+    ],
     "Resource":"*"
-    }
-  ]
+  }]
 }
 
 {
@@ -62,7 +67,6 @@ The following AWS permissions must be allowed for the policy to run.
      }
   }]
 }
-
 ```
 
 ## Supported Clouds


### PR DESCRIPTION
### Description

The sample AWS IAM policy JSON for the AWS Unused Volumes policy template had an incorrect version and was two separate documents with confusing formatting.

### Issues Resolved

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
