### PR TITLE
Fix parameter name typo and IAM policy formatting in AWS Unused IP Addresses policy template

### DIFF
--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Fix typo in parameter name to `param_exclude_tags`
+
 ## v2.0
 
 - initial release

--- a/cost/aws/unused_ip_addresses/README.md
+++ b/cost/aws/unused_ip_addresses/README.md
@@ -40,19 +40,19 @@ Provider tag value to match this policy: `aws`
 
 Required permissions in the provider:
 
-```
+```json
 {
   "Version": "2012-10-17",
   "Statement": [
-        {
-        "Effect": "Allow", 
-        "Action": [
-          "ec2:DescribeAddresses",
-          "ec2:ReleaseAddress"
-        ],
-        "Resource": "*"
-        }
-  ] 
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAddresses",
+        "ec2:ReleaseAddress"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 ```
 

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -17,7 +17,7 @@ info(
 # Parameters
 ###############################################################################
 
-parameter "param_exlude_tags" do
+parameter "param_exclude_tags" do
   type "list"
   label "Exclusion Tags Key:Value"
   description "AWS tag to ignore Elastic IPs. Format: Key:Value"
@@ -99,7 +99,7 @@ datasource "ds_aws_elastic_ip_address" do
 end
 
 datasource "ds_filter_ip" do
-  run_script $js_filter_ip_response, $ds_aws_elastic_ip_address, $param_exlude_tags
+  run_script $js_filter_ip_response, $ds_aws_elastic_ip_address, $param_exclude_tags
 end
 
 ###############################################################################
@@ -139,7 +139,7 @@ script "js_filter_ip_response", type: "javascript" do
     else{
       tagKeyValue=tagKeyValue.slice(2);
     }
-    //If the instance id is empty and IP tag does not match with entered param_exlude_tags
+    //If the instance id is empty and IP tag does not match with entered param_exclude_tags
     if(instance['instance_id']==""){
       if(!(isTagMatched)){
         result.push({

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -6,7 +6,7 @@ long_description ""
 severity "low" 
 category "Cost" 
 info(
-    version: "2.0",
+    version: "2.1",
     provider: "AWS",
     service: "EC2",
     policy_set: "Unused IP Addresses"

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -299,7 +299,7 @@ script "js_filter_aws_unattached_volumes", type:"javascript" do
     if(tagKeyValue === "" || tagKeyValue === " " || tagKeyValue == ""){
       tagKeyValue = "   < No Value >";
     }
-    //If the volume tag does not match with entered param_exlude_tags
+    //If the volume tag does not match with entered param_exclude_tags
     if(daysDifference > unattachedDays){
       if(!(isTagMatched)){
         content.push({


### PR DESCRIPTION
### Description

The AWS Unused IP Addresses policy template had a typo in the parameter name `param_exlude_tags` which should be `param_exclude_tags`. Also, the AWS IAM policy document for Credentials for the policy template was not formatted correctly in the README.

### Issues Resolved

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
