### PR TITLE
Pol 356 aws schedule instances action not working

### DIFF
--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- modified the policy to handle start or stop time without minute value
+
 ## v2.1 
 
 - fix description

--- a/cost/aws/schedule_instance/README.md
+++ b/cost/aws/schedule_instance/README.md
@@ -25,7 +25,7 @@ Instances are off during the weekend and start back up on Monday morning at 8:15
 This policy has the following input parameters required when launching the policy.
 
 - *Email addresses* - A list of email addresses to notify  
-- *Tags Key=Value* - List of tags that an Instance can have to exclude it from the list. 
+- *Exclusion Tags* - A list of AWS tags to ignore instances. Format: Key=Value. 
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 
 Please note that the "*Automatic Actions*" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
@@ -42,6 +42,11 @@ The following policy actions are taken on any resources found to be out of compl
 - delete schedule - removes the schedule tag
 
 ## Prerequisites
+
+### Schedule Tag Format
+
+The policy uses `schedule` tag value for scheduling the instance. The format should be like `8:15-17:30;MO,TU,WE,TH,FR;America/New_York`. Please refer to `Schedule Tag Example` section for more details.
+On leaving the minute field blank, policy will consider the minute as `00`.
 
 This policy uses [credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) for connecting to the  cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If  there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential  that is compatible with this policy. The information below should be consulted when creating the credential.   
 

--- a/cost/aws/schedule_instance/README.md
+++ b/cost/aws/schedule_instance/README.md
@@ -45,8 +45,8 @@ The following policy actions are taken on any resources found to be out of compl
 
 ### Schedule Tag Format
 
-The policy uses `schedule` tag value for scheduling the instance. The format should be like `8:15-17:30;MO,TU,WE,TH,FR;America/New_York`. Please refer to `Schedule Tag Example` section for more details.
-On leaving the minute field blank, policy will consider the minute as `00`.
+This policy uses `schedule` tag value for scheduling the instance. The format should be like `8:15-17:30;MO,TU,WE,TH,FR;America/New_York`. Please refer to `Schedule Tag Example` section for more details.
+On leaving the minute field blank, policy will consider the minute as `00` and same will be added to the schedule tag value.
 
 This policy uses [credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) for connecting to the  cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If  there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential  that is compatible with this policy. The information below should be consulted when creating the credential.   
 

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -84,7 +84,6 @@ datasource "ds_get_all_instances" do
     query "Filter.1.Name", "tag-key"
     query "Filter.1.Value.1", "schedule"
     query "Version", "2016-11-15"
-    ignore_status [403]
   end
   result do
     encoding "xml"

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Cost"
 severity "low"
 info(
-  version: "2.1",
+  version: "2.2",
   provider: "AWS",
   service: "EC2",
   policy_set:"Schedule Instance"
@@ -24,8 +24,8 @@ end
 
 parameter "param_tags_to_exclude" do
   type "list"
-  label "Tags Key=Value"
-  description "List of tags that an Instance can have to exclude it from the list"
+  label "Exclusion Tags"
+  description "A list of AWS tags to ignore instances. Format: Key=Value"
 end
 
 parameter "param_automatic_action" do
@@ -84,6 +84,7 @@ datasource "ds_get_all_instances" do
     query "Filter.1.Name", "tag-key"
     query "Filter.1.Value.1", "schedule"
     query "Version", "2016-11-15"
+    ignore_status [403]
   end
   result do
     encoding "xml"
@@ -268,9 +269,15 @@ define schedule_instance($data) return $all_response do
     $start_time = split($time_range,'-')[0]
     $start_hour = split($start_time, ':')[0]
     $start_minute = split($start_time, ':')[1]
+    if $start_minute==null
+      $start_minute='00';
+    end
     $stop_time = split($time_range,'-')[1]
     $stop_hour = split($stop_time, ':')[0]
     $stop_minute = split($stop_time, ':')[1]
+    if $stop_minute==null
+      $stop_minute='00';
+    end
     $start_rule = join(["FREQ=WEEKLY;BYDAY=",$rule])
     $stop_rule = join(["FREQ=WEEKLY;BYDAY=",$rule])
     $timezone = split($item['schedule'],';')[2]
@@ -406,9 +413,15 @@ define update_schedule($data, $param) return $all_response do
     $start_time = split($time_range,'-')[0]
     $start_hour = split($start_time, ':')[0]
     $start_minute = split($start_time, ':')[1]
+    if $start_minute==null
+      $start_minute='00';
+    end
     $stop_time = split($time_range,'-')[1]
     $stop_hour = split($stop_time, ':')[0]
     $stop_minute = split($stop_time, ':')[1]
+    if $stop_minute==null
+      $stop_minute='00';
+    end
     $start_rule = join(["FREQ=WEEKLY;BYDAY=",$rule])
     $stop_rule = join(["FREQ=WEEKLY;BYDAY=",$rule])
     $timezone = split($param,';')[2]

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -312,6 +312,8 @@ define schedule_instance($data) return $all_response do
         "Tag.1.Value": $next_start,
         "Tag.2.Key": "next_stop",
         "Tag.2.Value": $next_stop,
+        "Tag.3.Key": 'schedule',
+        "Tag.3.Value": join([$start_hour, ":", $start_minute, "-", $stop_hour, ":", $stop_minute, ";",$rule, ";", $timezone]),
         "Version": "2016-11-15"
       }
     )
@@ -445,7 +447,7 @@ define update_schedule($data, $param) return $all_response do
           "Tag.2.Key": "next_stop",
           "Tag.2.Value": $next_stop,
           "Tag.3.Key": 'schedule',
-          "Tag.3.Value": $param,
+          "Tag.3.Value": join([$start_hour, ":", $start_minute, "-", $stop_hour, ":", $stop_minute, ";",$rule, ";", $timezone]),
           "Version": "2016-11-15"
         }
       )


### PR DESCRIPTION
### Description

modified the policy to handle start or stop time values without minute value.


### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
