### PR TITLE
POL-384 Updated AWS Old snapshots deregister image action.

### DIFF
--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.5
+
+- Changed the default deregister image action from Yes to No.
+
 ## v2.4
 
 - Added EC2 DescribeRegions API action to get only Service Control Policy enabled Regions

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -5,7 +5,7 @@ short_description "Checks for snapshots older than specified number of days and,
 category "Cost"
 severity "low"
 info(
-  version: "2.4",
+  version: "2.5",
   provider:"AWS",
   service: "EBS", 
   policy_set: "Old Snapshots"
@@ -29,7 +29,7 @@ parameter "param_deregister_image" do
   label "Deregister Image"
   description "If Yes, the snapshot will be deleted along with the images, and if No the snapshot will not be considered for deletion."
   allowed_values "Yes","No"
-  default "Yes"
+  default "No"
 end
 
 parameter "param_exclude_tags" do


### PR DESCRIPTION
### Description

Changed the default deregister image action from Yes to No.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
