### PR TITLE
Fix AWS Regions with SCP for FinOps Policies

### DIFF
--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
@@ -75,7 +75,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
@@ -101,7 +101,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"
@@ -227,9 +226,9 @@ script "js_fnms_report", type: "javascript" do
       var path=sHost.substr(sHost.indexOf('/'))+'ManageSoftServices/ComplianceAPIService/ComplianceAPIService.asmx';
     } else{
       var path='/ManageSoftServices/ComplianceAPIService/ComplianceAPIService.asmx';
-	 }	
+	 }
     if (sHost.indexOf('/') > -1)  sHost = sHost.substr(0,sHost.indexOf('/'))
-	 
+
     // Find the right schema
     var sScheme = fnms_host.substr(0,fnms_host.indexOf('://'));
 

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -96,7 +96,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -80,7 +80,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
+++ b/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
@@ -98,7 +98,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
+++ b/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
@@ -78,7 +78,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/cost/aws/idle_compute_instances/idle_compute_instances.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances.pt
@@ -97,7 +97,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
+++ b/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
@@ -108,7 +108,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.7
+
+- Use `DescribeSnapshots` instead of `DescribeRegions` to more accurately check if the call is enabled by the
+  Service Control Policy in each region
+
 ## v2.6
 
 - Include Estimated Monthly Savings to each resource

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -5,9 +5,9 @@ short_description "Checks for snapshots older than specified number of days and,
 category "Cost"
 severity "low"
 info(
-  version: "2.5",
+  version: "2.7",
   provider:"AWS",
-  service: "EBS", 
+  service: "EBS",
   policy_set: "Old Snapshots"
 )
 
@@ -167,11 +167,11 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
-      query "Action", "DescribeRegions"
+      query "Action", "DescribeSnapshots"
       query "Version", "2016-11-15"
+      query "MaxResults", "5"
       ignore_status [403]
     end
     result do
@@ -249,7 +249,7 @@ end
 
 datasource "ds_snapshots_cost_mapping" do
   run_script $js_snapshots_cost_mapping, $ds_filter_ami_snapshots, $ds_snapshot_costs, $ds_currency_reference, $ds_currency_reference, $ds_billing_centers
-end 
+end
 
 ###############################################################################
 # Scripts
@@ -373,7 +373,7 @@ script "js_snapshots_cost_mapping", type:"javascript" do
     if (ds_billing_centers.length != 0 && _.size(cost_objects) > 0){
       var sum = _.reduce(_.compact(_.map(cost_objects, function(value){ return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
       var monthly_savings = sum*30;
-      total=total+monthly_savings;	  
+      total=total+monthly_savings;
       result.push({
         snapshotId : snapshot['snapshotId'],
         region : snapshot['region'],
@@ -454,14 +454,14 @@ script "js_filter_old_snapshots", type: "javascript" do
       for(var k=0; k < tags.length; k++){
         tag = tags[k];
         if((param_exclude_tags_lower.indexOf((tag['tagKey']).toLowerCase()) !== -1) || (param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1)){
-          isTagMatched = true;  
+          isTagMatched = true;
 		}
 
         // Constructing tags with comma separated to display in detail_template
         if((tag['tagValue']).length > 0){
-          tagKeyValue = tagKeyValue+" , "+tag['tagKey']+'='+tag['tagValue'];  
+          tagKeyValue = tagKeyValue+" , "+tag['tagKey']+'='+tag['tagValue'];
 		}else{
-          tagKeyValue = tagKeyValue+" , "+tag['tagKey'];  
+          tagKeyValue = tagKeyValue+" , "+tag['tagKey'];
 		}
 	  }
 
@@ -667,7 +667,7 @@ define delete_snapshot($item) do
   )
   $splitResult = $delete_response["code"]
   if $splitResult != 200
-   call sys_log("Inside delete_snapshot  defination", to_s($delete_response))
+   call sys_log("Inside delete_snapshot definition", to_s($delete_response))
   end
 end
 

--- a/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
+++ b/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
@@ -93,7 +93,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info.pt
@@ -66,7 +66,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -87,7 +87,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.8
+
+- Use `DescribeAddresses` instead of `DescribeRegions` to more accurately check if the call is enabled by the
+  Service Control Policy in each region
+
 ## v2.7
 
 - formatted the incident detail message to display if no savings data available

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -6,7 +6,7 @@ long_description ""
 severity "low"
 category "Cost"
 info(
-    version: "2.7",
+    version: "2.8",
     provider: "AWS",
     service: "EC2",
     policy_set: "Unused IP Addresses"
@@ -86,10 +86,9 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
-      query "Action", "DescribeRegions"
+      query "Action", "DescribeAddresses"
       query "Version", "2016-11-15"
       ignore_status [403]
     end
@@ -272,7 +271,7 @@ script "js_get_costs", type:"javascript" do
               "type": "equal",
               "value": "IP Address"
             }
-			
+
           ],
           "type": "and"
         }

--- a/cost/aws/unused_rds/unused_rds.pt
+++ b/cost/aws/unused_rds/unused_rds.pt
@@ -77,7 +77,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.9
+
+- Use `DescribeVolumes` instead of `DescribeRegions` to more accurately check if the call is enabled by the
+  Service Control Policy in each region
+
 ## v2.8
 
 - formatted the incident detail message to display if no savings data available

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -5,7 +5,7 @@ short_description "Checks for unused volumes and if no read/write operations per
 category "Cost"
 severity "low"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes"
@@ -105,11 +105,11 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
-      query "Action", "DescribeRegions"
+      query "Action", "DescribeVolumes"
       query "Version", "2016-11-15"
+      query "MaxResults", "5"
       ignore_status [403]
     end
     result do
@@ -353,13 +353,13 @@ script "js_aws_volumes_cloud_watch_read_byte_metrics", type:"javascript" do
   code <<-EOS
     var endDate = new Date().toISOString();
     var startDate = new Date(new Date().setDate(new Date().getDate() - unattachedDays)).toISOString();
-    var peroid = 2592000;
+    var period = 2592000;
     var datapoints = (unattachedDays / 30).toFixed(2);
     if(datapoints > 1440){
-      peroid = peroid * 60;
+      period = period * 60;
 	}
-    console.log("Period "+peroid);
-    peroid = ""+peroid+"";
+    console.log("Period "+period);
+    period = ""+period+"";
     metrics = {
      "auth": "auth_aws",
      "host": 'monitoring.'+region+'.amazonaws.com',
@@ -381,7 +381,7 @@ script "js_aws_volumes_cloud_watch_read_byte_metrics", type:"javascript" do
        'Dimensions.member.1.Value': volume_id,
        'StartTime': startDate,
        'EndTime': endDate,
-       'Period': peroid,
+       'Period': period,
        'Statistics.member.1': 'Maximum',
        'Statistics.member.2': 'Average',
        'Statistics.member.3': 'Minimum'

--- a/operational/aws/instance_scheduled_events/aws_instance_scheduled_events.pt
+++ b/operational/aws/instance_scheduled_events/aws_instance_scheduled_events.pt
@@ -82,7 +82,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -98,7 +98,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/operational/aws/subnet_name_sync/aws_subnet_name_sync.pt
+++ b/operational/aws/subnet_name_sync/aws_subnet_name_sync.pt
@@ -103,7 +103,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/operational/aws/vpc_name_sync/aws_vpc_name_sync.pt
+++ b/operational/aws/vpc_name_sync/aws_vpc_name_sync.pt
@@ -105,7 +105,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/operational/dbaas/aws/rds_backup/aws_rds_backup.pt
+++ b/operational/dbaas/aws/rds_backup/aws_rds_backup.pt
@@ -95,7 +95,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/policy_templates.code-workspace
+++ b/policy_templates.code-workspace
@@ -1,8 +1,8 @@
 {
-	"folders": [
-		{
-			"path": "."
-		}
+  "folders": [
+    {
+      "path": "."
+    }
   ],
   "settings": {
     "editor.detectIndentation": false,
@@ -15,7 +15,32 @@
     "markdownlint.config": {
       "default": true,
       "MD024": false
-    }
+    },
+    "cSpell.words": [
+      "Datasources",
+      "auditee",
+      "coenraads",
+      "datapoints",
+      "datasource",
+      "davidanson",
+      "dbaeumer",
+      "dotjoshjohnson",
+      "fknop",
+      "formulahendry",
+      "githubusercontent",
+      "jamesls",
+      "jmes",
+      "jmespath",
+      "markdownlint",
+      "nonamortized",
+      "orgs",
+      "rebornix",
+      "rightscale",
+      "streetsidesoftware",
+      "substr",
+      "textlintrc",
+      "unblended"
+    ]
   },
   "extensions": {
     "recommendations": [
@@ -27,7 +52,8 @@
       "dbaeumer.vscode-eslint",
       "dotjoshjohnson.xml",
       "coenraads.bracket-pair-colorizer-2",
-      "EditorConfig.EditorConfig"
+      "EditorConfig.EditorConfig",
+      "streetsidesoftware.code-spell-checker"
     ]
   }
 }

--- a/security/aws/clb_unencrypted/aws_clb_encryption.pt
+++ b/security/aws/clb_unencrypted/aws_clb_encryption.pt
@@ -80,7 +80,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
@@ -81,7 +81,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/security/aws/elb_unencrypted/aws_elb_encryption.pt
+++ b/security/aws/elb_unencrypted/aws_elb_encryption.pt
@@ -90,7 +90,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
@@ -87,7 +87,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
@@ -88,7 +88,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"

--- a/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
+++ b/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
@@ -88,7 +88,6 @@ datasource "ds_regions" do
     request do
       auth $auth_aws
       verb "GET"
-      host "ec2.amazonaws.com"
       host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
       path "/"
       query "Action", "DescribeRegions"


### PR DESCRIPTION
### Description

- Update the AWS Unused Volumes, AWS Old Snapshots, and AWS Unused IP
  Addresses policy templates to use the actual calls to determine if
  each region is available via SCP since we have discovered that using
  `DescribeRegions` in each particular region does not work reliably
  (the `DescribeRegions` call could be enabled for all regions while
  other calls are not).
- Add the Code Spell Checker extension to the suggested VS Code
  extensions and fix up some misspellings it found.
- Removed confusing ignored `host "ec2.amazonaws.com"` lines from all of
  the `ds_regions` datasources.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
