### PR TITLE
Check association ID in AWS Unused IP Addresses policy template

### DIFF
--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.9
 
-- Exclude Elastic IPs associated with network devices
+- Exclude Elastic IPs that have an Association ID
 
 ## v2.8
 

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Exclude EIPs associated with network devices
+
 ## v2.8
 
 - Use `DescribeAddresses` instead of `DescribeRegions` to more accurately check if the call is enabled by the

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.9
 
-- Exclude EIPs associated with network devices
+- Exclude Elastic IPs associated with network devices
 
 ## v2.8
 

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Use `DescribeAddresses` instead of `DescribeRegions` to more accurately check if the call is enabled by the
   Service Control Policy in each region
 
+## v2.8
+
+- Use `DescribeAddresses` instead of `DescribeRegions` to more accurately check if the call is enabled by the
+  Service Control Policy in each region
+
 ## v2.7
 
 - formatted the incident detail message to display if no savings data available

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -9,11 +9,6 @@
 - Use `DescribeAddresses` instead of `DescribeRegions` to more accurately check if the call is enabled by the
   Service Control Policy in each region
 
-## v2.8
-
-- Use `DescribeAddresses` instead of `DescribeRegions` to more accurately check if the call is enabled by the
-  Service Control Policy in each region
-
 ## v2.7
 
 - formatted the incident detail message to display if no savings data available

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -114,6 +114,7 @@ datasource "ds_aws_elastic_ip_address" do
       field "publicIp", xpath(col_item,"publicIp")
       field "domain" , xpath(col_item,"domain")
       field "instance_id", xpath(col_item, "instanceId")
+      field "network_interface_id", xpath(col_item, "networkInterfaceId")
       field "region", xpath(col_item,"networkBorderGroup")
       field "allocation_id", xpath(col_item,"allocationId")
       field "tags" do
@@ -319,7 +320,7 @@ script "js_filter_ip_response", type: "javascript" do
         tagKeyValue=tagKeyValue.slice(2);
       }
       //If the instance id is empty and IP tag does not match with entered param_exclude_tags
-      if(instance['instance_id']==""){
+      if(instance['instance_id']=="" && instance['network_interface_id'] == ""){
         if(!(isTagMatched)){
           result.push({
             all_tags : (tagKeyValue),

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -114,7 +114,6 @@ datasource "ds_aws_elastic_ip_address" do
       field "publicIp", xpath(col_item,"publicIp")
       field "domain" , xpath(col_item,"domain")
       field "instance_id", xpath(col_item, "instanceId")
-      field "network_interface_id", xpath(col_item, "networkInterfaceId")
       field "region", xpath(col_item,"networkBorderGroup")
       field "association_id", xpath(col_item,"associationId")
       field "allocation_id", xpath(col_item,"allocationId")

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -6,7 +6,7 @@ long_description ""
 severity "low"
 category "Cost"
 info(
-    version: "2.8",
+    version: "2.9",
     provider: "AWS",
     service: "EC2",
     policy_set: "Unused IP Addresses"
@@ -116,6 +116,7 @@ datasource "ds_aws_elastic_ip_address" do
       field "instance_id", xpath(col_item, "instanceId")
       field "network_interface_id", xpath(col_item, "networkInterfaceId")
       field "region", xpath(col_item,"networkBorderGroup")
+      field "association_id", xpath(col_item,"associationId")
       field "allocation_id", xpath(col_item,"allocationId")
       field "tags" do
         collect xpath(col_item, "tagSet/item") do
@@ -320,7 +321,7 @@ script "js_filter_ip_response", type: "javascript" do
         tagKeyValue=tagKeyValue.slice(2);
       }
       //If the instance id is empty and IP tag does not match with entered param_exclude_tags
-      if(instance['instance_id']=="" && instance['network_interface_id'] == ""){
+      if(instance['instance_id']=="" && instance['association_id'] == ""){
         if(!(isTagMatched)){
           result.push({
             all_tags : (tagKeyValue),


### PR DESCRIPTION
### Description

The AWS Unused IP Addresses policy template was detecting EIPs attached to NAT gateways as if they were not attached because it did not check the `associationId` field.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
