### PR TITLE
Use Policy Templates on a few parameters

### DIFF
--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Require a minimum value of `1` on the `snapshot_age` parameter
+
 ## v2.8
 
 - Added AWS Account ID to resource table

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -5,7 +5,7 @@ short_description "Checks for snapshots older than specified number of days and,
 category "Cost"
 severity "low"
 info(
-  version: "2.8",
+  version: "2.9",
   provider:"AWS",
   service: "EBS",
   policy_set: "Old Snapshots"
@@ -26,6 +26,7 @@ parameter "snapshot_age" do
   label "Snapshot age"
   default 30
   description "The number of days since the snapshot was created."
+  min_value 1
 end
 
 parameter "param_deregister_image" do

--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.11
+
+- Use a `min_value` of `1` on the `param_unattached_days` parameter
+
 ## v2.10
 
 - Adding AWS Account Id

--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.11
 
-- Use a `min_value` of `1` on the `param_unattached_days` parameter
+- Require a minimum value of `1` on the `param_unattached_days` parameter
 
 ## v2.10
 

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -5,7 +5,7 @@ short_description "Checks for unused volumes and if no read/write operations per
 category "Cost"
 severity "low"
 info(
-  version: "2.10",
+  version: "2.11",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes"
@@ -33,6 +33,7 @@ parameter "param_unattached_days" do
   label "Unused days"
   description "The number of days a volume has been unused. The days should be greater than zero"
   default 30
+  min_value 1
 end
 
 parameter "param_take_snapshot" do


### PR DESCRIPTION
### Description

- Add `min_value`s to the age parameters in the AWS Old Snapshots and AWS Unused Volumes policy templates

I believe the policies may work fine with other non-negative values, but I would think that `1` is a reasonable minimum.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
