### PR TITLE
POL-398-Display-cost-for-each-resources-under-all-the-azure-subscription-ids-available-from-Optima-in-Azure-policies-for-Savings

### DIFF
--- a/cost/azure/idle_compute_instances/CHANGELOG.md
+++ b/cost/azure/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.7
+
+- Updated policy to fetch cost details for multiple subscription ids from Optima
+- Modified escalation label and description for consistency
+
 ## v2.6
 
 - formatted the incident detail message to display if no savings data available

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Cost"
 severity "low"
 info(
-  version: "2.6",
+  version: "2.7",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle Compute Instances"
@@ -203,8 +203,9 @@ datasource "ds_billing_centers" do
 end
 
 datasource "ds_instance_costs" do
+  iterate $ds_subscriptions
   request do
-    run_script $js_get_costs, $ds_subscriptions, $ds_top_level_billing_centers, rs_org_id
+    run_script $js_get_costs, val(iter_item,"subscriptionId"), $ds_top_level_billing_centers, rs_org_id
   end
   result do
     encoding "json"
@@ -256,43 +257,41 @@ script "js_get_costs", type:"javascript" do
     }
     var start_date = getFormattedDailyDate(new Date(new Date().setDate(new Date().getDate() - 3)));
     var end_date = getFormattedDailyDate(new Date(new Date().setDate(new Date().getDate() - 2)));
-    for(var j in account_id){
-      var request = {
-        auth: "auth_rs",
-        host: "optima.rightscale.com",
-        verb: "POST",
-        path: "/bill-analysis/orgs/" + org + "/costs/select",
-        body_fields: {
-          "dimensions": ["resource_id", "resource_type"],
-          "granularity": "day",
-          "start_at": start_date,
-          "end_at": end_date,
-          "metrics": ["cost_nonamortized_unblended_adj"],
-          "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-          "limit": 10000,
-          "filter": {
-            "expressions": [
-              {
-                "dimension": "service",
-                "type": "equal",
-                "value": "Microsoft.Compute"
-              },
-              {
-                "dimension": "vendor_account",
-                "type": "equal",
-                "value": account_id[j]["subscriptionId"]
-              }
-            ],
-            "type": "and"
-          }
-        },
-        headers: {
-          "User-Agent": "RS Policies",
-          "Api-Version": "1.0"
-        },
-        ignore_status: [400]
-      }
-	}
+    var request = {
+      auth: "auth_rs",
+      host: "optima.rightscale.com",
+      verb: "POST",
+      path: "/bill-analysis/orgs/" + org + "/costs/select",
+      body_fields: {
+        "dimensions": ["resource_id", "resource_type"],
+        "granularity": "day",
+        "start_at": start_date,
+        "end_at": end_date,
+        "metrics": ["cost_nonamortized_unblended_adj"],
+        "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
+        "limit": 10000,
+        "filter": {
+          "expressions": [
+            {
+              "dimension": "service",
+              "type": "equal",
+              "value": "Microsoft.Compute"
+            },
+            {
+              "dimension": "vendor_account",
+              "type": "equal",
+              "value": account_id
+            }
+          ],
+          "type": "and"
+        }
+      },
+      headers: {
+        "User-Agent": "RS Policies",
+        "Api-Version": "1.0"
+      },
+      ignore_status: [400]
+    }
   EOS
 end
 
@@ -475,8 +474,8 @@ end
 
 escalation "email" do
   automatic true
-  label "Send Mail"
-  description "Sends incidents email"
+  label "Send Email"
+  description "Send incident email"
   email $param_email
 end
 

--- a/cost/azure/unattached_volumes/CHANGELOG.md
+++ b/cost/azure/unattached_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.4
+
+- Updated policy to fetch cost details for multiple subscription ids from Optima
+- Modified escalation label and description for consistency
+
 ## v2.3
 
 - formatted the incident detail message to display if no savings data available

--- a/cost/azure/unattached_volumes/azure_delete_unattached_volumes.pt
+++ b/cost/azure/unattached_volumes/azure_delete_unattached_volumes.pt
@@ -6,7 +6,7 @@ long_description ""
 severity "low"
 category "Cost"
 info(
-  version: "2.3",
+  version: "2.4",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes"
@@ -196,8 +196,9 @@ datasource "ds_top_level_billing_centers" do
 end
 
 datasource "ds_volume_costs" do
+  iterate $ds_subscriptions
   request do
-    run_script $js_get_costs, $ds_subscriptions, $ds_top_level_billing_centers, rs_org_id
+    run_script $js_get_costs, val(iter_item,"subscriptionId"), $ds_top_level_billing_centers, rs_org_id
   end
   result do
     encoding "json"
@@ -248,7 +249,6 @@ script "js_get_costs", type:"javascript" do
     }
     var start_date = getFormattedDailyDate(new Date(new Date().setDate(new Date().getDate() - 3)));
     var end_date = getFormattedDailyDate(new Date(new Date().setDate(new Date().getDate() - 2)));
-	for(var j in account_id){
     var request = {
       auth: "auth_rs",
       host: "optima.rightscale.com",
@@ -272,7 +272,7 @@ script "js_get_costs", type:"javascript" do
             {
               "dimension": "vendor_account",
               "type": "equal",
-              "value": account_id[j]["subscriptionId"]
+              "value": account_id
             }
           ],
           "type": "and"
@@ -284,7 +284,6 @@ script "js_get_costs", type:"javascript" do
       },
       ignore_status: [400]
     }
-	}
   EOS
 end
 
@@ -549,8 +548,8 @@ end
 
 escalation "send_email_report" do
   automatic true
-  label "Sends Email"
-  description "Sends Incident Email"
+  label "Send Email"
+  description "Send incident email"
   email $param_email
 end
 


### PR DESCRIPTION
POL-398-Display-cost-for-each-resources-under-all-the-azure-subscription-ids-available-from-Optima-in-Azure-policies-for-Savings
- Updated the policy to fetch and display cost for each resource under all the subscription ids from Optima
### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
