### PR TITLE
Updated JSON file with "m5.16xlarge" instead of m5.24xlarge

### DIFF
--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -144,7 +144,7 @@
   "m4.2xlarge": {"up": "m4.4xlarge", "down": "m4.xlarge", "superseded": {"regular":"m5.2xlarge", "next_gen":"", "burstable":"", "amd":"m5a.2xlarge"}, "ec2_classic": false, "enhanced_networking": false},
   "m4.4xlarge": {"up": "m4.10xlarge", "down": "m4.2xlarge", "superseded": {"regular":"m5.4xlarge", "next_gen":"", "burstable":"", "amd":"m5a.4xlarge"}, "ec2_classic": false, "enhanced_networking": false},
   "m4.10xlarge": {"up": "m4.16xlarge", "down": "m4.4xlarge", "superseded": {"regular":"m5.12xlarge", "next_gen":"", "burstable":"", "amd":"m5a.12xlarge"}, "ec2_classic": false, "enhanced_networking": false},
-  "m4.16xlarge": {"up": null, "down": "m4.10xlarge", "superseded": {"regular":"m5.24xlarge", "next_gen":"", "burstable":"", "amd":"m5a.24xlarge"}, "ec2_classic": false, "enhanced_networking": true},
+  "m4.16xlarge": {"up": null, "down": "m4.10xlarge", "superseded": {"regular":"m5.16xlarge", "next_gen":"", "burstable":"", "amd":"m5a.16xlarge"}, "ec2_classic": false, "enhanced_networking": true},
   "m5.large": {"up": "m5.xlarge", "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "m5.xlarge": {"up": "m5.2xlarge", "down": "m5.large", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "m5.2xlarge": {"up": "m5.4xlarge", "down": "m5.xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},


### PR DESCRIPTION
### Description

Updated Superseded value for m4.16xlarge from m5.24xlarge to  m5.16xlarge
 
### Issues Resolved

Right size for m4.16xlarge 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
