### PR TITLE
AWS Service Control Policy - Pagination Fix

### DIFF
--- a/compliance/aws/scp_audit/CHANGELOG.md
+++ b/compliance/aws/scp_audit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- Updated pagination to add `NextToken` to the body instead of query parameters on subsequent calls
+
 ## v2.1
 
 - Modified escalation label and description for consistency

--- a/compliance/aws/scp_audit/aws_scp_audit.pt
+++ b/compliance/aws/scp_audit/aws_scp_audit.pt
@@ -5,9 +5,9 @@ short_description "This policy checks to see if the provided service control pol
 category "Compliance"
 severity "medium"
 info(
-  version: "2.1",
+  version: "2.2",
   provider:"AWS",
-  service: "Org", 
+  service: "Org",
   policy_set: ""
 )
 
@@ -48,7 +48,7 @@ pagination "pagination_aws_json" do
     body_path jmes_path(response, "NextToken")
   end
   set_page_marker do
-    query "NextToken"
+    body_field "NextToken"
   end
 end
 

--- a/compliance/aws/scp_audit/aws_scp_audit.pt
+++ b/compliance/aws/scp_audit/aws_scp_audit.pt
@@ -68,7 +68,7 @@ datasource "ds_org_accounts" do
     header "User-Agent", "RS Policies"
     header "X-Amz-Target", "AWSOrganizationsV20161128.ListAccounts"
     header "Content-Type", "application/x-amz-json-1.1"
-    body_field "empty", "empty"
+    body "{}"
   end
   result do
     encoding "json"


### PR DESCRIPTION
### Description

Fixes pagination to add the `NextToken` to the body instead of query params

### Issues Resolved

N/A

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
