### PR TITLE
Configurable Optima org for AWS Old Snapshots and AWS Unused Volumes

### DIFF
--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.12
+
+- Add a parameter to override the Flexera One org ID to use when querying Optima for cases when the project is not
+  in the same org where the AWS bill is registered in Optima
+
 ## v2.11
 
 - Added a new input parameter to enter regions in order to support SCP (Service Control Policy) and CIS Standards

--- a/cost/aws/old_snapshots/README.md
+++ b/cost/aws/old_snapshots/README.md
@@ -6,9 +6,11 @@ This policy finds AWS snapshots in the given account which are older than the sp
 
 ### Policy savings details
 
-The policy includes the estimated savings. The estimated savings is recognized if the resource is terminated. Optima is used to receive the estimated savings which is the product of the most recent full day’s cost of the resource * 30. The savings is displayed in the Estimated Monthly Savings column. If the resource can not be found in Optima the value is n/a. The incident header includes the sum of each resource Estimated Monthly Savings in the Incident Header as Total Estimated Monthly Savings.
+The policy includes the estimated savings. The estimated savings is recognized if the resource is terminated. Optima is used to receive the estimated savings which is the product of the most recent full day’s cost of the resource \* 30. The savings are displayed in the *Estimated Monthly Savings* column. If the resource can not be found in Optima the value is `N/A`. The incident header includes the sum of each resource *Estimated Monthly Savings* as Total Estimated Monthly Savings.
 
-The Estimated Monthly Savings and Total Estimated Monthly Savings rounded to 3 decimal places, so the savings value will display $0.000 if estimated savings is less than $0.0005.
+If the AWS bill for the AWS account is registered in Optima in a different Flexera One org than the project where the policy template is applied, the *Flexera One Org ID for Optima* parameter can be set to the org where the AWS account is registered in Optima. Leaving this parameter set to `current` will result in using the same org as the project where the policy template is applied querying for Optima cost data.
+
+The *Estimated Monthly Savings* and *Total Estimated Monthly Savings* are rounded to 3 decimal places, so the savings value will display $0.000 if the estimated savings is less than $0.0005.
 
 ## Input Parameters
 
@@ -20,6 +22,7 @@ This policy has the following input parameters required when launching the polic
 - *Deregister Image* - If Yes, the snapshot will be deleted along with the images, and if No the snapshot will not be considered for deletion.
 - *Exclude Tags* - List of tags that a snapshot can have to exclude it from the list.
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
+- *Flexera One Org ID for Optima* - The Flexera One org ID for Optima queries used to determine estimated costs, by default the current org is used.
 
 Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
 For example, if a user selects the "Delete Snapshots" action while applying the policy, all the snapshots that didn't satisfy the policy condition will be deleted.

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -5,7 +5,7 @@ short_description "Checks for snapshots older than specified number of days and,
 category "Cost"
 severity "low"
 info(
-  version: "2.11",
+  version: "2.12",
   provider: "AWS",
   service: "EBS",
   policy_set: "Old Snapshots"

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 info(
   version: "2.11",
-  provider:"AWS",
+  provider: "AWS",
   service: "EBS",
   policy_set: "Old Snapshots"
 )
@@ -40,7 +40,7 @@ parameter "param_deregister_image" do
   type "string"
   label "Deregister Image"
   description "If Yes, the snapshot will be deleted along with the images, and if No the snapshot will not be considered for deletion."
-  allowed_values "Yes","No"
+  allowed_values "Yes", "No"
   default "No"
 end
 
@@ -58,13 +58,21 @@ parameter "param_automatic_action" do
   allowed_values ["Delete Snapshots"]
 end
 
+parameter "param_flexera_org_id_for_optima" do
+  type "string"
+  label "Flexera One Org ID for Optima"
+  description "The Flexera One org ID for Optima queries used to determine estimated costs, by default the current org is used"
+  default "current"
+  allowed_pattern /^(current|[0-9]+)$/
+end
+
 ###############################################################################
 # Authentication
 ###############################################################################
 
 #authenticate with AWS
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
@@ -97,19 +105,23 @@ datasource "ds_currency_reference" do
   end
 end
 
+datasource "ds_flexera_optima" do
+  run_script $js_flexera_optima, $param_flexera_org_id_for_optima, rs_org_id
+end
+
 datasource "ds_currency_code" do
   request do
     auth $auth_rs
     host rs_optima_host
-    path join(["/bill-analysis/orgs/",rs_org_id,"/settings/currency_code"])
+    path join(["/bill-analysis/orgs/", val($ds_flexera_optima, "org_id"), "/settings/currency_code"])
     header "Api-Version", "0.1"
     header "User-Agent", "RS Policies"
-	ignore_status [403]
+  ignore_status [403]
   end
   result do
     encoding "json"
-    field "id", jmes_path(response,"id")
-    field "value", jmes_path(response,"value")
+    field "id", jmes_path(response, "id")
+    field "value", jmes_path(response, "value")
   end
 end
 
@@ -117,19 +129,19 @@ datasource "ds_billing_centers" do
   request do
     auth $auth_rs
     host rs_optima_host
-    path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    path join(["/analytics/orgs/", val($ds_flexera_optima, "org_id"), "/billing_centers"])
     header "Api-Version", "1.0"
     header "User-Agent", "RS Policies"
     query "view", "allocation_table"
-	ignore_status [403]
+  ignore_status [403]
   end
   result do
     encoding "json"
-    collect jmes_path(response,"[*]") do
-      field "href", jmes_path(col_item,"href")
-      field "id", jmes_path(col_item,"id")
-      field "name", jmes_path(col_item,"name")
-      field "parent_id", jmes_path(col_item,"parent_id")
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
     end
   end
 end
@@ -140,13 +152,13 @@ end
 
 datasource "ds_snapshot_costs" do
   request do
-    run_script $js_get_costs, $ds_get_caller_identity, $ds_top_level_billing_centers, rs_org_id
+    run_script $js_get_costs, $ds_get_caller_identity, $ds_top_level_billing_centers, val($ds_flexera_optima, "org_id")
   end
   result do
     encoding "json"
-    collect jmes_path(response,"rows[*]") do
-      field "resource_id", jmes_path(col_item,"dimensions.resource_id")
-      field "cost_nonamortized_unblended_adj", jmes_path(col_item,"metrics.cost_nonamortized_unblended_adj")
+    collect jmes_path(response, "rows[*]") do
+      field "resource_id", jmes_path(col_item, "dimensions.resource_id")
+      field "cost_nonamortized_unblended_adj", jmes_path(col_item, "metrics.cost_nonamortized_unblended_adj")
     end
   end
 end
@@ -187,9 +199,9 @@ datasource "ds_get_caller_identity" do
   result do
     encoding "xml"
     collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
-      field "account",xpath(col_item, "Account")
+      field "account", xpath(col_item, "Account")
     end
- end
+  end
 end
 
 datasource "ds_describe_snapshots" do
@@ -201,13 +213,13 @@ datasource "ds_describe_snapshots" do
     encoding "xml"
     collect xpath(response, "//DescribeSnapshotsResponse/snapshotSet/item", "array") do
       field "tags" do
-        collect xpath(col_item,"tagSet/item") do
+        collect xpath(col_item, "tagSet/item") do
           field "tagKey", xpath(col_item, "key")
           field "tagValue", xpath(col_item, "value")
         end
       end
-      field "region",val(iter_item, "region")
-      field "snapshotId", xpath(col_item,"snapshotId")
+      field "region", val(iter_item, "region")
+      field "snapshotId", xpath(col_item, "snapshotId")
       field "startTime", xpath(col_item, "startTime")
       field "ownerId", xpath(col_item, "ownerId")
       field "volumeSize", xpath(col_item, "volumeSize")
@@ -249,7 +261,7 @@ end
 # Scripts
 ###############################################################################
 
-script "js_regions", type:"javascript" do
+script "js_regions", type: "javascript" do
   parameters "user_entered_regions", "all_regions"
   result "regions"
   code <<-EOS
@@ -281,6 +293,16 @@ script "js_regions", type:"javascript" do
   EOS
 end
 
+script "js_flexera_optima", type: "javascript" do
+  parameters "flexera_org_id_for_optima", "current_flexera_org_id"
+  result "flexera_optima"
+  code <<-EOS
+  var flexera_optima = {
+    org_id: flexera_org_id_for_optima == "current" ? current_flexera_org_id : flexera_org_id_for_optima,
+  };
+  EOS
+end
+
 script "js_top_level_bc", type: "javascript" do
   parameters "billing_centers"
   result "filtered_billing_centers"
@@ -289,8 +311,8 @@ script "js_top_level_bc", type: "javascript" do
   EOS
 end
 
-script "js_get_costs", type:"javascript" do
-  parameters  "account_id","billing_centers","org"
+script "js_get_costs", type: "javascript" do
+  parameters "account_id", "billing_centers", "org"
   result "request"
   code <<-EOS
     // returns date formatted as string: YYYY-mm-dd
@@ -344,13 +366,13 @@ script "js_get_costs", type:"javascript" do
         "User-Agent": "RS Policies",
         "Api-Version": "1.0"
       },
-	   ignore_status: [400]
+      ignore_status: [400]
     }
   EOS
 end
 
-script "js_snapshots_cost_mapping", type:"javascript" do
-  parameters  "snapshots","snapshot_costs","ds_currency_code","ds_currency_reference","ds_billing_centers","ds_get_caller_identity"
+script "js_snapshots_cost_mapping", type: "javascript" do
+  parameters "snapshots", "snapshot_costs", "ds_currency_code", "ds_currency_reference", "ds_billing_centers", "ds_get_caller_identity"
   result "results"
   code <<-EOS
 
@@ -484,15 +506,15 @@ script "js_filter_old_snapshots", type: "javascript" do
         tag = tags[k];
         if((param_exclude_tags_lower.indexOf((tag['tagKey']).toLowerCase()) !== -1) || (param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1)){
           isTagMatched = true;
-		}
+        }
 
         // Constructing tags with comma separated to display in detail_template
         if((tag['tagValue']).length > 0){
           tagKeyValue = tagKeyValue+" , "+tag['tagKey']+'='+tag['tagValue'];
-		}else{
+        }else{
           tagKeyValue = tagKeyValue+" , "+tag['tagKey'];
-		}
-	  }
+        }
+      }
 
       if(tagKeyValue === "" || tagKeyValue === " " || tagKeyValue == ""){
         tagKeyValue = "   < No Value >";
@@ -509,16 +531,16 @@ script "js_filter_old_snapshots", type: "javascript" do
             tagKeyValue : (tagKeyValue.slice(2)),
             daysOld : daysOld,
             volumeSize : snapshot['volumeSize']
-		  })
-		}
-	  }
-	}
+          })
+        }
+      }
+    }
     results = _.sortBy(results,'region');
     results = _.sortBy(results,'daysOld');
   EOS
 end
 
-script "js_get_snapshot_ami", type:"javascript" do
+script "js_get_snapshot_ami", type: "javascript" do
   result "results"
   parameters "snapshotId", "region"
   code <<-EOS
@@ -541,7 +563,7 @@ script "js_get_snapshot_ami", type:"javascript" do
    EOS
 end
 
-script "js_filter_ami_snapshots", type:"javascript" do
+script "js_filter_ami_snapshots", type: "javascript" do
   result "results"
   parameters "snapshotImagesList", "snapshotsList", "ds_get_caller_identity"
   code <<-EOS
@@ -634,14 +656,14 @@ escalation "esc_delete_snapshot" do
   automatic contains($param_automatic_action, "Delete Snapshots")
   label "Delete Snapshots"
   description "Approval to delete all selected snapshots"
-  run "take_action",data,$param_deregister_image
+  run "take_action", data, $param_deregister_image
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define take_action($data,$param_deregister_image) return $all_responses do
+define take_action($data, $param_deregister_image) return $all_responses do
   $all_responses = []
   $image_ids = []
   foreach $item in $data do
@@ -670,7 +692,7 @@ define deregisterImageFromSnapshot($item, $region) do
       auth: $$auth_aws,
       https: true,
       verb: "get",
-      host: "ec2."+$region+".amazonaws.com",
+      host: "ec2." + $region + ".amazonaws.com",
       href: "/",
       query_strings: {
       "Action": "DeregisterImage",
@@ -690,7 +712,7 @@ define delete_snapshot($item) do
     auth: $$auth_aws,
     https: true,
     verb: "get",
-    host: "ec2."+$item["region"]+".amazonaws.com",
+    host: "ec2." + $item["region"] + ".amazonaws.com",
     href: "/",
     query_strings: {
       "Action": "DeleteSnapshot",
@@ -709,7 +731,7 @@ define sys_log($subject, $detail) do
     notify: "None",
     audit_entry: {
       auditee_href: @@account,
-      summary: "AWS Old Snapshots :- "+ $subject,
+      summary: "AWS Old Snapshots :- " + $subject,
       detail: $detail
     }
   )

--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.14
+
+- Add a parameter to override the Flexera One org ID to use when querying Optima for cases when the project is not
+  in the same org where the AWS bill is registered in Optima
+
 ## v2.13
 
 - Added a new input parameter to enter regions in order to support SCP (Service Control Policy) and CIS Standards

--- a/cost/aws/unused_volumes/README.md
+++ b/cost/aws/unused_volumes/README.md
@@ -11,8 +11,11 @@ Optionally, the user can specify one or more tags that if found on a volume will
 
 ### Policy savings details
 
-The policy includes the estimated savings. The estimated savings is recognized if the resource is terminated. Optima is used to receive the estimated savings which is the product of the most recent full day’s cost of the resource * 30. The savings is displayed in the Estimated Monthly Savings column. If the resource can not be found in Optima the value is n/a. The incident detail message includes the sum of each resource Estimated Monthly Savings as Total Estimated Monthly Savings.
-If the user is not having the minimum required role of `billing_center_viewer` or if there is no enough data received from Optima to calculate savings, appropriate message is displayed in the incident detail message along with the estimated monthly savings column value as N/A in the incident table.
+The policy includes the estimated savings. The estimated savings is recognized if the resource is terminated. Optima is used to receive the estimated savings which is the product of the most recent full day’s cost of the resource \* 30. The savings are displayed in the *Estimated Monthly Savings* column. If the resource can not be found in Optima the value is `N/A`. The incident detail message includes the sum of each resource *Estimated Monthly Savings* as *Total Estimated Monthly Savings*.
+
+If the AWS bill for the AWS account is registered in Optima in a different Flexera One org than the project where the policy template is applied, the *Flexera One Org ID for Optima* parameter can be set to the org where the AWS account is registered in Optima. Leaving this parameter set to `current` will result in using the same org as the project where the policy template is applied querying for Optima cost data.
+
+If the user does not have the minimum required role of `billing_center_viewer` or if there is not enough data received from Optima to calculate savings, an appropriate message is displayed in the incident detail message along with the estimated monthly savings column value as `N/A` in the incident table.
 
 ## Input Parameters
 
@@ -24,6 +27,7 @@ This policy has the following input parameters required when launching the polic
 - *Exclude Tags.* - A list of tags used to excluded volumes from the incident.
 - *Create Final Snapshot* - Boolean for whether or not to take a final snapshot before deleting
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
+- *Flexera One Org ID for Optima* - The Flexera One org ID for Optima queries used to determine estimated costs, by default the current org is used.
 
 Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
 For example if a user selects the "Delete Volumes" action while applying the policy, all the volumes that didn't satisfy the policy condition will be deleted.

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -5,7 +5,7 @@ short_description "Checks for unused volumes and if no read/write operations per
 category "Cost"
 severity "low"
 info(
-  version: "2.13",
+  version: "2.14",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes"

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -47,7 +47,7 @@ parameter "param_take_snapshot" do
   type "string"
   label "Create Final Snapshot"
   description "Boolean for whether or not to take a final snapshot before deleting."
-  allowed_values "Yes","No"
+  allowed_values "Yes", "No"
   default "Yes"
 end
 
@@ -58,13 +58,21 @@ parameter "param_automatic_action" do
   allowed_values ["Delete Volumes"]
 end
 
+parameter "param_flexera_org_id_for_optima" do
+  type "string"
+  label "Flexera One Org ID for Optima"
+  description "The Flexera One org ID for Optima queries used to determine estimated costs, by default the current org is used"
+  default "current"
+  allowed_pattern /^(current|[0-9]+)$/
+end
+
 ###############################################################################
 # Authentication
 ###############################################################################
 
 #Authenticate with AWS
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
@@ -116,13 +124,13 @@ end
 datasource "ds_unattached_volumes_list" do
   iterate $ds_regions
     request do
-      run_script $js_aws_unattached_volumes_list, val(iter_item,"region")
+      run_script $js_aws_unattached_volumes_list, val(iter_item, "region")
     end
   result do
   encoding "xml"
-  collect xpath(response, "//DescribeVolumesResponse/volumeSet/item","array") do
+  collect xpath(response, "//DescribeVolumesResponse/volumeSet/item", "array") do
     field "tags" do
-      collect xpath(col_item,"tagSet/item") do
+      collect xpath(col_item, "tagSet/item") do
         field "tagKey", xpath(col_item, "key")
         field "tagValue", xpath(col_item, "value")
       end
@@ -137,8 +145,8 @@ datasource "ds_unattached_volumes_list" do
     field "snapshot_id", xpath(col_item, "snapshotId")
     field "volume_Type", xpath(col_item, "volumeType")
     field "region", val(iter_item, "region")
-    field "createdTime", xpath(col_item,"createTime")
-    field "size", xpath(col_item,"size")
+    field "createdTime", xpath(col_item, "createTime")
+    field "size", xpath(col_item, "size")
    end
   end
 end
@@ -150,13 +158,13 @@ end
 datasource "ds_volume_read_bytes_metrics" do
   iterate $ds_unattached_volumes_map
   request do
-    run_script $js_aws_volumes_cloud_watch_read_byte_metrics, val(iter_item,"vol_id"), val(iter_item,"region"), $param_unattached_days
+    run_script $js_aws_volumes_cloud_watch_read_byte_metrics, val(iter_item, "vol_id"), val(iter_item, "region"), $param_unattached_days
   end
   result do
     encoding "json"
-    collect jmes_path(response,"GetMetricStatisticsResponse.GetMetricStatisticsResult") do
-      field "volumeId", val(iter_item,"vol_id")
-      field "dataPoints", jmes_path(col_item,"Datapoints")
+    collect jmes_path(response, "GetMetricStatisticsResponse.GetMetricStatisticsResult") do
+      field "volumeId", val(iter_item, "vol_id")
+      field "dataPoints", jmes_path(col_item, "Datapoints")
     end
   end
 end
@@ -164,19 +172,19 @@ end
 datasource "ds_volume_write_bytes_metrics" do
   iterate $ds_unattached_volumes_map
   request do
-    run_script $js_aws_volumes_cloud_watch_write_byte_metrics, val(iter_item,"vol_id"), val(iter_item,"region"), $param_unattached_days
+    run_script $js_aws_volumes_cloud_watch_write_byte_metrics, val(iter_item, "vol_id"), val(iter_item, "region"), $param_unattached_days
   end
   result do
     encoding "json"
-    collect jmes_path(response,"GetMetricStatisticsResponse.GetMetricStatisticsResult") do
-      field "volumeId", val(iter_item,"vol_id")
-      field "dataPoints", jmes_path(col_item,"Datapoints")
+    collect jmes_path(response, "GetMetricStatisticsResponse.GetMetricStatisticsResult") do
+      field "volumeId", val(iter_item, "vol_id")
+      field "dataPoints", jmes_path(col_item, "Datapoints")
     end
   end
 end
 
 datasource "ds_check_volumes_read_or_write_operations" do
-  run_script $js_check_volumes_read_or_write_operations,$ds_unattached_volumes_map,$ds_volume_read_bytes_metrics,$ds_volume_write_bytes_metrics
+  run_script $js_check_volumes_read_or_write_operations, $ds_unattached_volumes_map, $ds_volume_read_bytes_metrics, $ds_volume_write_bytes_metrics
 end
 
 datasource "ds_currency_reference" do
@@ -187,19 +195,23 @@ datasource "ds_currency_reference" do
   end
 end
 
+datasource "ds_flexera_optima" do
+  run_script $js_flexera_optima, $param_flexera_org_id_for_optima, rs_org_id
+end
+
 datasource "ds_currency_code" do
   request do
     auth $auth_rs
     host rs_optima_host
-    path join(["/bill-analysis/orgs/",rs_org_id,"/settings/currency_code"])
+    path join(["/bill-analysis/orgs/", val($ds_flexera_optima, "org_id"), "/settings/currency_code"])
     header "Api-Version", "0.1"
     header "User-Agent", "RS Policies"
     ignore_status [403]
   end
   result do
     encoding "json"
-    field "id", jmes_path(response,"id")
-    field "value", jmes_path(response,"value")
+    field "id", jmes_path(response, "id")
+    field "value", jmes_path(response, "value")
   end
 end
 
@@ -207,7 +219,7 @@ datasource "ds_billing_centers" do
   request do
     auth $auth_rs
     host rs_optima_host
-    path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    path join(["/analytics/orgs/", val($ds_flexera_optima, "org_id"), "/billing_centers"])
     header "Api-Version", "1.0"
     header "User-Agent", "RS Policies"
     query "view", "allocation_table"
@@ -215,11 +227,11 @@ datasource "ds_billing_centers" do
   end
   result do
     encoding "json"
-    collect jmes_path(response,"[*]") do
-      field "href", jmes_path(col_item,"href")
-      field "id", jmes_path(col_item,"id")
-      field "name", jmes_path(col_item,"name")
-      field "parent_id", jmes_path(col_item,"parent_id")
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
     end
   end
 end
@@ -241,20 +253,20 @@ datasource "ds_get_caller_identity" do
   result do
     encoding "xml"
     collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
-      field "account",xpath(col_item, "Account")
+      field "account", xpath(col_item, "Account")
     end
  end
 end
 
 datasource "ds_volume_costs" do
   request do
-    run_script $js_get_costs, $ds_get_caller_identity, $ds_top_level_billing_centers, rs_org_id
+    run_script $js_get_costs, $ds_get_caller_identity, $ds_top_level_billing_centers, val($ds_flexera_optima, "org_id")
   end
   result do
     encoding "json"
-    collect jmes_path(response,"rows[*]") do
-      field "resource_id", jmes_path(col_item,"dimensions.resource_id")
-      field "cost_nonamortized_unblended_adj", jmes_path(col_item,"metrics.cost_nonamortized_unblended_adj")
+    collect jmes_path(response, "rows[*]") do
+      field "resource_id", jmes_path(col_item, "dimensions.resource_id")
+      field "cost_nonamortized_unblended_adj", jmes_path(col_item, "metrics.cost_nonamortized_unblended_adj")
     end
   end
 end
@@ -267,7 +279,7 @@ end
 # Script
 ###############################################################################
 
-script "js_regions", type:"javascript" do
+script "js_regions", type: "javascript" do
   parameters "user_entered_regions", "all_regions"
   result "regions"
   code <<-EOS
@@ -300,8 +312,8 @@ script "js_regions", type:"javascript" do
 end
 
 #https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html
-script "js_aws_unattached_volumes_list", type:"javascript" do
-  parameters  "region"
+script "js_aws_unattached_volumes_list", type: "javascript" do
+  parameters "region"
   result "results"
   code <<-EOS
   results = {
@@ -319,8 +331,8 @@ script "js_aws_unattached_volumes_list", type:"javascript" do
   EOS
 end
 
-script "js_filter_aws_unattached_volumes", type:"javascript" do
-  parameters "ds_unattached_volumes_list","param_exclude_tags","unattachedDays"
+script "js_filter_aws_unattached_volumes", type: "javascript" do
+  parameters "ds_unattached_volumes_list", "param_exclude_tags", "unattachedDays"
   result "content"
   code <<-EOS
   var param_exclude_tags_lower=[];
@@ -373,8 +385,8 @@ script "js_filter_aws_unattached_volumes", type:"javascript" do
   EOS
 end
 
-script "js_aws_volumes_cloud_watch_read_byte_metrics", type:"javascript" do
-  parameters "volume_id","region","unattachedDays"
+script "js_aws_volumes_cloud_watch_read_byte_metrics", type: "javascript" do
+  parameters "volume_id", "region", "unattachedDays"
   result "metrics"
   code <<-EOS
     var endDate = new Date().toISOString();
@@ -383,7 +395,7 @@ script "js_aws_volumes_cloud_watch_read_byte_metrics", type:"javascript" do
     var datapoints = (unattachedDays / 30).toFixed(2);
     if(datapoints > 1440){
       period = period * 60;
-	}
+    }
     console.log("Period "+period);
     period = ""+period+"";
     metrics = {
@@ -416,8 +428,8 @@ script "js_aws_volumes_cloud_watch_read_byte_metrics", type:"javascript" do
   EOS
 end
 
-script "js_aws_volumes_cloud_watch_write_byte_metrics", type:"javascript" do
-  parameters "volume_id","region","unattachedDays"
+script "js_aws_volumes_cloud_watch_write_byte_metrics", type: "javascript" do
+  parameters "volume_id", "region", "unattachedDays"
   result "metrics"
   code <<-EOS
     var endDate = new Date().toISOString();
@@ -426,7 +438,7 @@ script "js_aws_volumes_cloud_watch_write_byte_metrics", type:"javascript" do
     var dataPoints = (unattachedDays/30).toFixed(2);
     if(dataPoints > 1440){
       period = period * 60;
-	}
+    }
     period = ""+period+"";
     console.log("Period "+period);
     metrics = {
@@ -459,8 +471,8 @@ script "js_aws_volumes_cloud_watch_write_byte_metrics", type:"javascript" do
   EOS
 end
 
-script "js_check_volumes_read_or_write_operations", type:'javascript' do
-  parameters "volumesList","volumesReadMetricsData","volumesWriteMetricsData"
+script "js_check_volumes_read_or_write_operations", type: 'javascript' do
+  parameters "volumesList", "volumesReadMetricsData", "volumesWriteMetricsData"
   result "unattachedVolumes"
   code <<-EOS
   var unattachedVolumes = [];
@@ -473,10 +485,10 @@ script "js_check_volumes_read_or_write_operations", type:'javascript' do
         var readMetricDataPoints = readMetricData['dataPoints'];
         if(readMetricDataPoints.length > 0){
           readWriteOperationDone = true;
-		}
+        }
         break;
-	  }
-	}
+      }
+    }
     if(!readWriteOperationDone){
       for(var k=0; k < volumesWriteMetricsData.length; k++){
         var writeMetricData = volumesWriteMetricsData[k];
@@ -484,11 +496,11 @@ script "js_check_volumes_read_or_write_operations", type:'javascript' do
           var writeMetricDataPoints = writeMetricData['dataPoints'];
           if(writeMetricDataPoints.length > 0){
             readWriteOperationDone = true;
-		  }
+          }
           break;
-		}
-	  }
-	}
+        }
+      }
+    }
     if(!readWriteOperationDone){
       unattachedVolumes.push({
         volumeId : volume['vol_id'],
@@ -499,9 +511,19 @@ script "js_check_volumes_read_or_write_operations", type:'javascript' do
         createdTime : volume['createdTime'],
         size : volume['size'],
         savings:"N/A"
-	  })
-	}
+      })
+    }
   }
+  EOS
+end
+
+script "js_flexera_optima", type: "javascript" do
+  parameters "flexera_org_id_for_optima", "current_flexera_org_id"
+  result "flexera_optima"
+  code <<-EOS
+  var flexera_optima = {
+    org_id: flexera_org_id_for_optima == "current" ? current_flexera_org_id : flexera_org_id_for_optima,
+  };
   EOS
 end
 
@@ -511,11 +533,11 @@ script "js_top_level_bc", type: "javascript" do
   code <<-EOS
   var filtered_billing_centers =
     _.reject(billing_centers, function(bc){ return bc.parent_id != null });
-EOS
+  EOS
 end
 
-script "js_get_costs", type:"javascript" do
-  parameters  "account_id","billing_centers","org"
+script "js_get_costs", type: "javascript" do
+  parameters "account_id", "billing_centers", "org"
   result "request"
   code <<-EOS
     // returns date formatted as string: YYYY-mm-dd
@@ -575,7 +597,7 @@ script "js_get_costs", type:"javascript" do
 end
 
 script "js_volume_cost_mapping", type:"javascript" do
-  parameters  "volumes","volume_costs","ds_currency_code","ds_currency_reference", "ds_billing_centers", "ds_get_caller_identity"
+  parameters "volumes", "volume_costs", "ds_currency_code", "ds_currency_reference", "ds_billing_centers", "ds_get_caller_identity"
   result "result"
   code <<-EOS
   var unused_volumes=[];
@@ -685,7 +707,7 @@ policy "policy_unattached_volumes_list" do
     EOS
     escalate $report_unused_volumes
     escalate $delete_volumes
-    check eq(size(val(data,"unused_volumes")),0)
+    check eq(size(val(data, "unused_volumes")), 0)
     export "unused_volumes" do
       resource_level true
       field "accountId" do
@@ -729,14 +751,14 @@ escalation "delete_volumes" do
   automatic contains($param_automatic_action, "Delete Volumes")
   label "Delete Volumes"
   description "Approval to delete all selected volumes"
-  run "take_action",data,$param_take_snapshot
+  run "take_action", data, $param_take_snapshot
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define take_action($data,$param_take_snapshot) return $all_responses do
+define take_action($data, $param_take_snapshot) return $all_responses do
   # If you want to see the audit entries. Please set $$debug = true
   $$debug = false
   $all_responses = []
@@ -760,7 +782,7 @@ define create_volumes_snapshot($item) return $status_code do
     auth: $$auth_aws,
     https: true,
     verb: "get",
-    host: "ec2."+$item["region"]+".amazonaws.com",
+    host: "ec2." + $item["region"] + ".amazonaws.com",
     href: "/",
     query_strings: {
       "Action": "CreateSnapshot",
@@ -768,7 +790,7 @@ define create_volumes_snapshot($item) return $status_code do
       "VolumeId": $item["id"]
     }
   )
-  call sys_log("Create Volumes Snapshot Response ",to_s($response))
+  call sys_log("Create Volumes Snapshot Response ", to_s($response))
   $status_code = $response["code"]
 
   if $status_code == 200
@@ -787,7 +809,6 @@ define create_volumes_snapshot($item) return $status_code do
           $status_code = 400
           $snapshot_status = "completed"
         end
-
       end
     end
   end
@@ -798,7 +819,7 @@ define delete_volume($item) return $status_code do
     auth: $$auth_aws,
     https: true,
     verb: "get",
-    host: "ec2."+$item["region"]+".amazonaws.com",
+    host: "ec2." + $item["region"] + ".amazonaws.com",
     href: "/",
     query_strings: {
       "Action": "DeleteVolume",
@@ -806,23 +827,23 @@ define delete_volume($item) return $status_code do
       "VolumeId": $item["id"]
     }
   )
-  call sys_log("Delete Volumes Response ",to_s($delete_response))
+  call sys_log("Delete Volumes Response ", to_s($delete_response))
   $volume_delete_status = $delete_response["code"]
   if $volume_delete_status != 200
     $volume_delete_body = $delete_response["body"]
-    $split_body = split($volume_delete_body,"<Message>")
-    $split_final_message = split($split_body[1],"</Message>");
-     call create_tag($item["region"],$item["id"],to_s($split_final_message[0]))
+    $split_body = split($volume_delete_body, "<Message>")
+    $split_final_message = split($split_body[1], "</Message>");
+     call create_tag($item["region"], $item["id"], to_s($split_final_message[0]))
   end
 end
 
 define get_snapshot_status($snapshotId) return $snapshot_status do
-  call sys_log("Inside Get Snapshot Details Snapshot Id ",$snapshotId)
+  call sys_log("Inside Get Snapshot Details Snapshot Id ", $snapshotId)
   $snapshot_response = http_request(
     auth: $$auth_aws,
     https: true,
     verb: "get",
-    host: "ec2."+$item["region"]+".amazonaws.com",
+    host: "ec2." + $item["region"] + ".amazonaws.com",
     href: "/",
     query_strings: {
       "Action": "DescribeSnapshots",
@@ -830,17 +851,17 @@ define get_snapshot_status($snapshotId) return $snapshot_status do
       "SnapshotId": $snapshotId
     }
   )
-  call sys_log("Get Snapshot Details ",to_s($snapshot_response))
+  call sys_log("Get Snapshot Details ", to_s($snapshot_response))
   $snapshot_status = $snapshot_response["body"]["DescribeSnapshotsResponse"]["snapshotSet"]["item"]["status"]
 end
 
-define create_tag($region,$volumeId,$message) do
-  call sys_log("Create Tag  ",$volumeId)
+define create_tag($region, $volumeId, $message) do
+  call sys_log("Create Tag  ", $volumeId)
   $snapshot_response = http_request(
     auth: $$auth_aws,
     https: true,
     verb: "get",
-    host: "ec2."+$region+".amazonaws.com",
+    host: "ec2." + $region + ".amazonaws.com",
     href: "/",
     query_strings: {
       "Action": "CreateTags",
@@ -858,7 +879,7 @@ define sys_log($subject, $detail) do
       notify: "None",
       audit_entry: {
         auditee_href: @@account,
-        summary: "AWS Delete Unused Volumes Policy "+ $subject,
+        summary: "AWS Delete Unused Volumes Policy " + $subject,
         detail: $detail
       }
     )


### PR DESCRIPTION
### Description

Adds a parameter to the AWS Old Snapshots and AWS Unused Volumes policy templates to override the Flexera One org ID to use when querying Optima for cases when the project is not in the same org where the AWS bill is registered in Optima. The default value for this new parameter is `current` which duplicates the old behavior of using the `rs_org_id` keyword to get the current org ID, so the new behavior will only be triggered if a different org ID value is entered in the parameter. This behaviour is needed in order to get useful cost/savings estimates from these policies for the Flexera FinOps Team's use case where various engineering Flexera One projects that are associated with AWS accounts are not in the same org where we have the AWS bill registered in Optima.

### Issues Resolved

None

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
