### PR TITLE
Improve action error handling and debug logging for FinOps

### DIFF
--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Improve error handling and debug logging so that errors from taking action are actually surfaced
 - Add a `param_log_to_cm_audit_entries` parameter to control whether action debug logging is sent to CM Audit
-  Entries; this should be left turned off on Flexera EU
+  Entries; this should be left set to No on Flexera EU
 
 ## v2.12
 

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.13
+
+- Improve error handling and debug logging so that errors from taking action are actually surfaced
+- Add a `param_log_to_cm_audit_entries` parameter to control whether action debug logging is sent to CM Audit
+  Entries; this should be left turned off on Flexera EU
+
 ## v2.12
 
 - Add a parameter to override the Flexera One org ID to use when querying Optima for cases when the project is not

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -612,9 +612,10 @@ policy "pol_utilization" do
   validate $ds_snapshots_cost_mapping do
     summary_template "AWS Account ID: {{with index data.result 0}}{{ .accountId }}{{end}} - {{ len data.result }} rows containing AWS old snapshot data"
     detail_template <<-EOS
-    The following {{ len data.result }} old snapshots, for AWS Account: {{with index data.result 0}}{{ .accountId }}{{end}}, have exceeded the specified age of: {{ parameters.snapshot_age }} days old.\n
-    {{data.message}}
-    EOS
+The following {{ len data.result }} old snapshots, for AWS Account: {{with index data.result 0}}{{ .accountId }}{{end}}, have exceeded the specified age of: {{ parameters.snapshot_age }} days old.
+
+{{data.message}}
+EOS
     escalate $ese_email
     escalate $esc_delete_snapshot
     check eq(size(val(data, "result")), 0)
@@ -743,7 +744,7 @@ end
 
 define skip_error_and_append($subject) do
   $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
-  $_error_behavior = 'skip'
+  $_error_behavior = "skip"
 end
 
 define check_response_and_append_if_error($response, $request_description, $errors) return $errors do
@@ -758,7 +759,7 @@ define sys_log($subject, $detail) do
       notify: "None",
       audit_entry: {
         auditee_href: @@account,
-        summary: "AWS Old Snapshots :- " + $subject,
+        summary: "AWS Old Snapshots Policy :- " + $subject,
         detail: $detail
       }
     )

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -753,7 +753,7 @@ define check_response_and_append_if_error($response, $request_description, $erro
   end
 end
 
-define sys_log($subject, $detail) do
+define sys_log($subject, $detail) on_error: skip_error_and_append("Creating audit entry for " + $subject) do
   if $$debug
     rs_cm.audit_entries.create(
       notify: "None",

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -66,6 +66,14 @@ parameter "param_flexera_org_id_for_optima" do
   allowed_pattern /^(current|[0-9]+)$/
 end
 
+parameter "param_log_to_cm_audit_entries" do
+  type "string"
+  label "Log to CM Audit Entries"
+  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left turned off on Flexera EU"
+  default "No"
+  allowed_values "Yes", "No"
+end
+
 ###############################################################################
 # Authentication
 ###############################################################################
@@ -656,37 +664,42 @@ escalation "esc_delete_snapshot" do
   automatic contains($param_automatic_action, "Delete Snapshots")
   label "Delete Snapshots"
   description "Approval to delete all selected snapshots"
-  run "take_action", data, $param_deregister_image
+  run "take_action", data, $param_deregister_image, $param_log_to_cm_audit_entries
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define take_action($data, $param_deregister_image) return $all_responses do
-  $all_responses = []
-  $image_ids = []
+define take_action($data, $param_deregister_image, $param_log_to_cm_audit_entries) do
+  $$debug = $param_log_to_cm_audit_entries == "Yes"
+  $$errors = []
   foreach $item in $data do
-    sub on_error: skip do
+    sub on_error: skip_error_and_append($item["id"]) do
+      $image_ids = []
+
       if $item["snapshotImageIdFormat"] != ""
         $image_ids = split($item["snapshotImageIdFormat"], ",")
       end
 
       if $param_deregister_image == "Yes"
-        call deregisterImageFromSnapshot($image_ids, $item["region"])
-        call delete_snapshot($item)
+        call deregisterImageFromSnapshot($image_ids, $item["region"], $$errors) retrieve $$errors
+        call delete_snapshot($item, $$errors) retrieve $$errors
       elsif $param_deregister_image == "No"
         if empty?($image_ids)
-          call delete_snapshot($item)
+          call delete_snapshot($item, $$errors) retrieve $$errors
         end
       end
     end
-
-    $image_ids = []
+  end
+  if size($$errors) > 0
+    $error = join($$errors, "\n")
+    call sys_log("Errors", $error)
+    raise $error
   end
 end
 
-define deregisterImageFromSnapshot($item, $region) do
+define deregisterImageFromSnapshot($item, $region, $errors) return $errors do
   foreach $image in $item do
     $deregister_response = http_request(
       auth: $$auth_aws,
@@ -699,15 +712,16 @@ define deregisterImageFromSnapshot($item, $region) do
       "Version": "2016-11-15",
       "ImageId": strip($image)
       }
-   )
-  $deregisterResponseResult = $deregister_response["code"]
+    )
+    call check_response_and_append_if_error($deregister_response, "Deregister Image", $errors) retrieve $errors
+    $deregisterResponseResult = $deregister_response["code"]
     if $deregisterResponseResult != 200
       call sys_log("Deregister image snapshot", to_s($deregister_response))
     end
   end
 end
 
-define delete_snapshot($item) do
+define delete_snapshot($item, $errors) return $errors do
   $delete_response = http_request(
     auth: $$auth_aws,
     https: true,
@@ -720,19 +734,33 @@ define delete_snapshot($item) do
       "SnapshotId.1": strip($item["id"])
     }
   )
+  call check_response_and_append_if_error($delete_response, "Delete Snapshot", $errors) retrieve $errors
   $splitResult = $delete_response["code"]
   if $splitResult != 200
    call sys_log("Inside delete_snapshot definition", to_s($delete_response))
   end
 end
 
+define skip_error_and_append($subject) do
+  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
+  $_error_behavior = 'skip'
+end
+
+define check_response_and_append_if_error($response, $request_description, $errors) return $errors do
+  if $response["code"] > 299 || $response["code"] < 200
+    $errors << "Unexpected status code from " + $request_description + " request\n  " + to_s($response)
+  end
+end
+
 define sys_log($subject, $detail) do
-  rs_cm.audit_entries.create(
-    notify: "None",
-    audit_entry: {
-      auditee_href: @@account,
-      summary: "AWS Old Snapshots :- " + $subject,
-      detail: $detail
-    }
-  )
+  if $$debug
+    rs_cm.audit_entries.create(
+      notify: "None",
+      audit_entry: {
+        auditee_href: @@account,
+        summary: "AWS Old Snapshots :- " + $subject,
+        detail: $detail
+      }
+    )
+  end
 end

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -1,7 +1,7 @@
 name "AWS Old Snapshots"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for snapshots older than specified number of days and, optionally, deletes them. See the [README](https://github.com/flexera/policy_templates/tree/master/cost/aws/old_snapshots) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+short_description "Checks for snapshots older than a specified number of days and, optionally, deletes them. See the [README](https://github.com/flexera/policy_templates/tree/master/cost/aws/old_snapshots) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
 category "Cost"
 severity "low"
 info(

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -69,7 +69,7 @@ end
 parameter "param_log_to_cm_audit_entries" do
   type "string"
   label "Log to CM Audit Entries"
-  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left turned off on Flexera EU"
+  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU"
   default "No"
   allowed_values "Yes", "No"
 end

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -5,7 +5,7 @@ short_description "Checks for snapshots older than specified number of days and,
 category "Cost"
 severity "low"
 info(
-  version: "2.12",
+  version: "2.13",
   provider: "AWS",
   service: "EBS",
   policy_set: "Old Snapshots"

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Improve error handling and debug logging so that errors from taking action are actually surfaced
 - Add a `param_log_to_cm_audit_entries` parameter to control whether action debug logging is sent to CM Audit
-  Entries; this should be left turned off on Flexera EU
+  Entries; this should be left set to No on Flexera EU
 
 ## v2.13
 

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.14
+
+- Improve error handling and debug logging so that errors from taking action are actually surfaced
+- Add a `param_log_to_cm_audit_entries` parameter to control whether action debug logging is sent to CM Audit
+  Entries; this should be left turned off on Flexera EU
+
 ## v2.13
 
 - Modified policy to use per hour cost for unused IP from AWS pricing document for calculating estimated savings.

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -42,6 +42,14 @@ parameter "param_automatic_action" do
   allowed_values ["Delete Unused IPs"]
 end
 
+parameter "param_log_to_cm_audit_entries" do
+  type "string"
+  label "Log to CM Audit Entries"
+  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left turned off on Flexera EU"
+  default "No"
+  allowed_values "Yes", "No"
+end
+
 ###############################################################################
 # Authentication
 ###############################################################################
@@ -321,7 +329,7 @@ escalation "esc_delete_ip_address" do
   automatic contains($param_automatic_action, "Delete Unused IPs")
   label "Delete IP"
   description "Delete Selected Unused IP"
-  run "delete_unused_instances", data
+  run "delete_unused_instances", data, $param_log_to_cm_audit_entries
 end
 
 ###############################################################################
@@ -332,8 +340,8 @@ policy "policy_unused_ip_addresses" do
   validate $ds_ip_cost_mapping do
     summary_template "AWS Account ID: {{ data.accountId }} - {{ len data.ip_list }} Unused IP Addresses Found"
     detail_template <<-EOS
-    {{data.message}}
-    EOS
+{{data.message}}
+EOS
     check eq(size(val(data, "ip_list")),0)
     escalate $esc_email
     escalate $esc_delete_ip_address
@@ -369,50 +377,71 @@ end
 # Cloud Workflow
 ###############################################################################
 
-define delete_unused_instances($data) return $all_responses do
+define delete_unused_instances($data, $param_log_to_cm_audit_entries) do
+  $$debug = $param_log_to_cm_audit_entries == "Yes"
+  $$errors = []
   $all_responses = []
   foreach $item in $data do
-    sub on_error: skip do
+    sub on_error: skip_error_and_append($item["id"]) do
       if $item["domain"]=="standard"
         $response = http_request(
           verb: "get",
-          host: join(["ec2.", $item["region"],".amazonaws.com"]),
+          host: join(["ec2.", $item["region"], ".amazonaws.com"]),
           auth: $$auth_aws,
           href: "/",
           query_strings:{
-            "Action":"ReleaseAddress",
-            "PublicIp":$item["publicIp"],
-            "Version":"2016-11-15"
+            "Action": "ReleaseAddress",
+            "PublicIp": $item["id"],
+            "Version": "2016-11-15"
           },
           https: true
         )
       elsif $item["domain"]=="vpc"
         $response = http_request(
           verb: "get",
-          host: join(["ec2.", $item["region"],".amazonaws.com"]),
+          host: join(["ec2.", $item["region"], ".amazonaws.com"]),
           auth: $$auth_aws,
           href: "/",
           query_strings:{
-            "Action":"ReleaseAddress",
-            "AllocationId":$item["allocation_id"],
-            "Version":"2016-11-15"
+            "Action": "ReleaseAddress",
+            "AllocationId": $item["allocation_id"],
+            "Version": "2016-11-15"
           },
           https: true
         )
       end
+      call check_response_and_append_if_error($response, "Release Address " + $item["id"], $$errors) retrieve $$errors
       $all_responses << $response
     end
   end
-  call sys_log('Unused Elastic IPs response',to_s($all_responses))
+  call sys_log("Responses", to_s($all_responses))
+  if size($$errors) > 0
+    $error = join($$errors, "\n")
+    call sys_log("Errors", $error)
+    raise $error
+  end
+end
+
+define skip_error_and_append($subject) do
+  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
+  $_error_behavior = "skip"
+end
+
+define check_response_and_append_if_error($response, $request_description, $errors) return $errors do
+  if $response["code"] > 299 || $response["code"] < 200
+    $errors << "Unexpected status code from " + $request_description + " request\n  " + to_s($response)
+  end
 end
 
 define sys_log($subject, $detail) do
-  rs_cm.audit_entries.create(
-    notify: "None",
-    audit_entry: {
-      auditee_href: @@account,
-      summary: "AWS Delete "+ $subject,
-      detail: $detail
-    }
-  )
+  if $$debug
+    rs_cm.audit_entries.create(
+      notify: "None",
+      audit_entry: {
+        auditee_href: @@account,
+        summary: "AWS Unused IP Addresses Policy :- " + $subject,
+        detail: $detail
+      }
+    )
+  end
 end

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -6,7 +6,7 @@ long_description ""
 severity "low"
 category "Cost"
 info(
-    version: "2.13",
+    version: "2.14",
     provider: "AWS",
     service: "EC2",
     policy_set: "Unused IP Addresses"

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -433,7 +433,7 @@ define check_response_and_append_if_error($response, $request_description, $erro
   end
 end
 
-define sys_log($subject, $detail) do
+define sys_log($subject, $detail) on_error: skip_error_and_append("Creating audit entry for " + $subject) do
   if $$debug
     rs_cm.audit_entries.create(
       notify: "None",

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -45,7 +45,7 @@ end
 parameter "param_log_to_cm_audit_entries" do
   type "string"
   label "Log to CM Audit Entries"
-  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left turned off on Flexera EU"
+  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU"
   default "No"
   allowed_values "Yes", "No"
 end

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -1,7 +1,7 @@
 name "AWS Unused IP Addresses"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks AWS for unused IP Addresses and deletes them. See the [README](https://github.com/flexera/policy_templates/tree/master/cost/aws/unused_ip_addresses/) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+short_description "Checks AWS for unused IP Addresses and, optionally, deletes them. See the [README](https://github.com/flexera/policy_templates/tree/master/cost/aws/unused_ip_addresses/) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
 long_description ""
 severity "low"
 category "Cost"

--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.15
+
+- Improve error handling and debug logging so that errors from taking action are actually surfaced
+- Add a `param_log_to_cm_audit_entries` parameter to control whether action debug logging is sent to CM Audit
+  Entries; this should be left turned off on Flexera EU
+
 ## v2.14
 
 - Add a parameter to override the Flexera One org ID to use when querying Optima for cases when the project is not

--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Improve error handling and debug logging so that errors from taking action are actually surfaced
 - Add a `param_log_to_cm_audit_entries` parameter to control whether action debug logging is sent to CM Audit
-  Entries; this should be left turned off on Flexera EU
+  Entries; this should be left set to No on Flexera EU
 
 ## v2.14
 

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -711,8 +711,8 @@ policy "policy_unattached_volumes_list" do
   validate $ds_volume_cost_mapping do
     summary_template "AWS Account ID: {{ data.accountId }} - {{ len data.unused_volumes }} Unused Volumes Found"
     detail_template <<-EOS
-    {{data.message}}
-    EOS
+{{data.message}}
+EOS
     escalate $report_unused_volumes
     escalate $delete_volumes
     check eq(size(val(data, "unused_volumes")), 0)
@@ -899,7 +899,7 @@ define sys_log($subject, $detail) do
       notify: "None",
       audit_entry: {
         auditee_href: @@account,
-        summary: "AWS Delete Unused Volumes Policy " + $subject,
+        summary: "AWS Unused Volumes Policy :- " + $subject,
         detail: $detail
       }
     )

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -5,7 +5,7 @@ short_description "Checks for unused volumes and if no read/write operations per
 category "Cost"
 severity "low"
 info(
-  version: "2.14",
+  version: "2.15",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes"

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -768,19 +768,19 @@ end
 
 define take_action($data, $param_take_snapshot, $param_log_to_cm_audit_entries) do
   $$debug = $param_log_to_cm_audit_entries == "Yes"
-  $errors = []
+  $$errors = []
   foreach $item in $data do
     $snapshot_status_code = 200
     if $param_take_snapshot == "Yes"
-      call create_volumes_snapshot($item, $errors) retrieve $status_code, $errors
+      call create_volumes_snapshot($item, $$errors) retrieve $status_code, $$errors
       $snapshot_status_code = $status_code
     end
     if $snapshot_status_code == 200
-      call delete_volume($item, $errors) retrieve $status_code, $errors
+      call delete_volume($item, $$errors) retrieve $status_code, $$errors
     end
   end
-  if size($errors) > 0
-    $error = join($errors, "\n")
+  if size($$errors) > 0
+    $error = join($$errors, "\n")
     call sys_log("Errors", $error)
     raise $error
   end
@@ -891,13 +891,18 @@ define create_tag($region, $volumeId, $message, $errors) return $errors do
   call check_response_and_append_if_error($response, "Create Tag", $errors) retrieve $errors
 end
 
+define skip_error_and_append($subject) do
+  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
+  $_error_behavior = "skip"
+end
+
 define check_response_and_append_if_error($response, $request_description, $errors) return $errors do
   if $response["code"] > 299 || $response["code"] < 200
     $errors << "Unexpected status code from " + $request_description + " request\n  " + to_s($response)
   end
 end
 
-define sys_log($subject, $detail) do
+define sys_log($subject, $detail) on_error: skip_error_and_append("Creating audit entry for " + $subject) do
   if $$debug
     rs_cm.audit_entries.create(
       notify: "None",

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -1,7 +1,7 @@
 name "AWS Unused Volumes"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for unused volumes and if no read/write operations performed within a specified number of days and, optionally, deletes them. See the [README](https://github.com/flexera/policy_templates/tree/master/cost/aws/unused_volumes) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+short_description "Checks for unused volumes with no read/write operations performed within a specified number of days and, optionally, deletes them. See the [README](https://github.com/flexera/policy_templates/tree/master/cost/aws/unused_volumes) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
 category "Cost"
 severity "low"
 info(

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -814,12 +814,15 @@ define create_volumes_snapshot($item, $errors) return $status_code, $errors do
 
       while $condition_check !~ $snapshot_status do
         sleep(2)
-        call get_snapshot_status(to_s($snapshotId)) retrieve $status
+        call get_snapshot_status(to_s($snapshotId), []) retrieve $status, $snapshot_errors
         $snapshot_status = $status
 
-        if $snapshot_status == "error"
+        if $snapshot_status == "error" || size($snapshot_errors) > 0
           $status_code = 400
           $snapshot_status = "completed"
+          foreach $error in $snapshot_errors do
+            $errors << $error
+          end
         end
       end
     end
@@ -850,7 +853,7 @@ define delete_volume($item, $errors) return $status_code, $errors do
   end
 end
 
-define get_snapshot_status($snapshotId) return $snapshot_status do
+define get_snapshot_status($snapshotId, $errors) return $snapshot_status, $errors do
   call sys_log("Inside Get Snapshot Details Snapshot Id ", $snapshotId)
   $snapshot_response = http_request(
     auth: $$auth_aws,
@@ -864,6 +867,7 @@ define get_snapshot_status($snapshotId) return $snapshot_status do
       "SnapshotId": $snapshotId
     }
   )
+  call check_response_and_append_if_error($snapshot_response, "Describe Snapshot " + $snapshotId, $errors) retrieve $errors
   call sys_log("Get Snapshot Details ", to_s($snapshot_response))
   $snapshot_status = $snapshot_response["body"]["DescribeSnapshotsResponse"]["snapshotSet"]["item"]["status"]
 end

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -66,6 +66,14 @@ parameter "param_flexera_org_id_for_optima" do
   allowed_pattern /^(current|[0-9]+)$/
 end
 
+parameter "param_log_to_cm_audit_entries" do
+  type "string"
+  label "Log to CM Audit Entries"
+  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left turned off on Flexera EU"
+  default "No"
+  allowed_values "Yes", "No"
+end
+
 ###############################################################################
 # Authentication
 ###############################################################################
@@ -751,31 +759,34 @@ escalation "delete_volumes" do
   automatic contains($param_automatic_action, "Delete Volumes")
   label "Delete Volumes"
   description "Approval to delete all selected volumes"
-  run "take_action", data, $param_take_snapshot
+  run "take_action", data, $param_take_snapshot, $param_log_to_cm_audit_entries
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define take_action($data, $param_take_snapshot) return $all_responses do
-  # If you want to see the audit entries. Please set $$debug = true
-  $$debug = false
-  $all_responses = []
+define take_action($data, $param_take_snapshot, $param_log_to_cm_audit_entries) do
+  $$debug = $param_log_to_cm_audit_entries == "Yes"
+  $errors = []
   foreach $item in $data do
     $snapshot_status_code = 200
     if $param_take_snapshot == "Yes"
-      call create_volumes_snapshot($item) retrieve $status_code
+      call create_volumes_snapshot($item, $errors) retrieve $status_code, $errors
       $snapshot_status_code = $status_code
     end
     if $snapshot_status_code == 200
-      call delete_volume($item) retrieve $status_code
+      call delete_volume($item, $errors) retrieve $status_code, $errors
     end
+  end
+  if size($errors) > 0
+    $error = join($errors, "\n")
+    call sys_log("Errors", $error)
+    raise $error
   end
 end
 
-define create_volumes_snapshot($item) return $status_code do
-  $response = []
+define create_volumes_snapshot($item, $errors) return $status_code, $errors do
   $status_code
   $snapshot_status = "pending"
   $response = http_request(
@@ -790,6 +801,7 @@ define create_volumes_snapshot($item) return $status_code do
       "VolumeId": $item["id"]
     }
   )
+  call check_response_and_append_if_error($response, "Create Volumes Snapshot", $errors) retrieve $errors
   call sys_log("Create Volumes Snapshot Response ", to_s($response))
   $status_code = $response["code"]
 
@@ -814,7 +826,7 @@ define create_volumes_snapshot($item) return $status_code do
   end
 end
 
-define delete_volume($item) return $status_code do
+define delete_volume($item, $errors) return $status_code, $errors do
   $delete_response = http_request(
     auth: $$auth_aws,
     https: true,
@@ -827,13 +839,14 @@ define delete_volume($item) return $status_code do
       "VolumeId": $item["id"]
     }
   )
+  call check_response_and_append_if_error($delete_response, "Delete Volume", $errors) retrieve $errors
   call sys_log("Delete Volumes Response ", to_s($delete_response))
   $volume_delete_status = $delete_response["code"]
   if $volume_delete_status != 200
     $volume_delete_body = $delete_response["body"]
     $split_body = split($volume_delete_body, "<Message>")
     $split_final_message = split($split_body[1], "</Message>");
-     call create_tag($item["region"], $item["id"], to_s($split_final_message[0]))
+    call create_tag($item["region"], $item["id"], to_s($split_final_message[0]), $errors) retrieve $errors
   end
 end
 
@@ -855,9 +868,9 @@ define get_snapshot_status($snapshotId) return $snapshot_status do
   $snapshot_status = $snapshot_response["body"]["DescribeSnapshotsResponse"]["snapshotSet"]["item"]["status"]
 end
 
-define create_tag($region, $volumeId, $message) do
+define create_tag($region, $volumeId, $message, $errors) return $errors do
   call sys_log("Create Tag  ", $volumeId)
-  $snapshot_response = http_request(
+  $response = http_request(
     auth: $$auth_aws,
     https: true,
     verb: "get",
@@ -871,6 +884,13 @@ define create_tag($region, $volumeId, $message) do
       "Tag.1.Value": to_s($message)
     }
   )
+  call check_response_and_append_if_error($response, "Create Tag", $errors) retrieve $errors
+end
+
+define check_response_and_append_if_error($response, $request_description, $errors) return $errors do
+  if $response["code"] > 299 || $response["code"] < 200
+    $errors << "Unexpected status code from " + $request_description + " request\n  " + to_s($response)
+  end
 end
 
 define sys_log($subject, $detail) do

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -69,7 +69,7 @@ end
 parameter "param_log_to_cm_audit_entries" do
   type "string"
   label "Log to CM Audit Entries"
-  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left turned off on Flexera EU"
+  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU"
   default "No"
   allowed_values "Yes", "No"
 end

--- a/policy_templates.code-workspace
+++ b/policy_templates.code-workspace
@@ -18,8 +18,10 @@
     },
     "cSpell.words": [
       "Datasources",
+      "Uncommenting",
       "auditee",
       "coenraads",
+      "curr",
       "datapoints",
       "datasource",
       "davidanson",
@@ -39,7 +41,8 @@
       "streetsidesoftware",
       "substr",
       "textlintrc",
-      "unblended"
+      "unblended",
+      "usagetype"
     ]
   },
   "extensions": {


### PR DESCRIPTION
### Description

- Improve the error handling and debug logging of the AWS Old Snapshots, AWS Unused IP Addresses, and AWS Unused Volumes policy templates so that errors from CWF actions are actually surfaced.
- Add a `param_log_to_cm_audit_entries` parameter to control whether action debug logging is sent to CM Audit Entries; this should be left turned off on Flexera EU.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
