### PR TITLE
CET-977 Use GitHub GraphQL for enforcing branch protection

### DIFF
--- a/compliance/github/repository_branch_protection/CHANGELOG.md
+++ b/compliance/github/repository_branch_protection/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## v3.0
+## v2.3
 
 - Use GitHub GraphQL API to decrease the number of API calls
-- Remove "branches" parameter and check the protection on the default branch
+- Add option to include default branch regardless of branch selection
 
 ## v2.2
 

--- a/compliance/github/repository_branch_protection/CHANGELOG.md
+++ b/compliance/github/repository_branch_protection/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.0
+
+- Use GitHub GraphQL API to decrease the number of API calls
+- Remove "branches" parameter and check the protection on the default branch
+
 ## v2.2
 
 - Modified escalation label and description for consistency

--- a/compliance/github/repository_branch_protection/README.md
+++ b/compliance/github/repository_branch_protection/README.md
@@ -2,15 +2,14 @@
 
 ## What it does
 
-This Policy Template gets the top-level / parent Teams for a GitHub.com Org and creates an incident if any do not match the whitelisted values.
+Gets the repositories under a list of GitHub.com Organizations and creates incidents for any that do not have protection enabled for their default branch.
 
 ## Input Parameters
 
 1. GitHub.com Organizations to check - Example: `flexera`
-1. Branches that should be protected - Example: `master`
 1. Repositories that are whitelisted from the policy - Example: `flexera/repository-name`
 1. Email address to send escalation emails to - Example: `noreply@example.com`
-1. Protection Option: Enforce all configured restrictions for administrators. 
+1. Protection Option: Enforce all configured restrictions for administrators.
 1. Protection Option: Require at least this number of approving review on a pull request, before merging.
 1. Automatic Actions: When this value is set, this policy will automatically take the selected action(s).
 
@@ -32,7 +31,7 @@ credentials listed when you apply the policy, please contact your cloud admin an
 
 ### Credential configuration
 
-For administrators [creating and managing credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) to use with this policy, the following information is needed: 
+For administrators [creating and managing credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) to use with this policy, the following information is needed:
 
 Provider tag value to match this policy: `github`
 
@@ -43,3 +42,4 @@ This policy requires permissions to access GitHub.com API as the Owner of the Or
 ## Cost
 
 This Policy Template does not launch any instances, and so does not incur any cloud costs.
+

--- a/compliance/github/repository_branch_protection/README.md
+++ b/compliance/github/repository_branch_protection/README.md
@@ -7,6 +7,8 @@ Gets the repositories under a list of GitHub.com Organizations and creates incid
 ## Input Parameters
 
 1. GitHub.com Organizations to check - Example: `flexera`
+1. Branches that should be protected - Example: `master`
+1. Include default branch regardless of branches list.
 1. Repositories that are whitelisted from the policy - Example: `flexera/repository-name`
 1. Email address to send escalation emails to - Example: `noreply@example.com`
 1. Protection Option: Enforce all configured restrictions for administrators.

--- a/compliance/github/repository_branch_protection/repository_branch_protection.pt
+++ b/compliance/github/repository_branch_protection/repository_branch_protection.pt
@@ -5,7 +5,7 @@ long_description ""
 severity "medium"
 category "Compliance"
 info(
-  version: "2.2",
+  version: "3.0",
   provider: "GitHub",
   service: "",
   policy_set: ""

--- a/compliance/github/repository_branch_protection/repository_branch_protection.pt
+++ b/compliance/github/repository_branch_protection/repository_branch_protection.pt
@@ -1,11 +1,11 @@
 name "GitHub.com Repository Branches without Protection"
 rs_pt_ver 20180301
-short_description "Gets the repositories under a list of GitHub.com Organizations and creates incidents for any that do not have protection enabled for their default branch.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/github/repository_branch_protection) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+short_description "Gets the repositories under a list of GitHub.com Organizations and creates incidents for any that do not have protection enabled for selected branches.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/github/repository_branch_protection) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
 long_description ""
 severity "medium"
 category "Compliance"
 info(
-  version: "3.0",
+  version: "2.3",
   provider: "GitHub",
   service: "",
   policy_set: ""
@@ -19,6 +19,19 @@ end
 parameter "param_orgs" do
   type "list"
   label "Organizations on GitHub.com to scan"
+end
+
+parameter "param_branches" do
+  type "list"
+  label "Git branches that should be protected"
+  default ["master"]
+end
+
+parameter "param_include_default_branch" do
+  type "string"
+  label "Protect default branch"
+  default "true"
+  allowed_values ["false","true"]
 end
 
 parameter "param_whitelist" do
@@ -64,11 +77,11 @@ pagination "github_pagination" do
 end
 
 datasource "ds_github_query" do
-  run_script $js_github_query, $param_orgs
+  run_script $js_github_query, $param_orgs, $param_branches
 end
 
 script "js_github_query", type: "javascript" do
-  parameters "orgNames"
+  parameters "orgNames", "branches"
   result "result"
   code <<-EOS
   var query = 'query getRepositories($currentCursor: String) { \
@@ -83,14 +96,9 @@ script "js_github_query", type: "javascript" do
               login \
             } \
             defaultBranchRef { \
-              name \
-              branchProtectionRule { \
-                isAdminEnforced \
-                requiredApprovingReviewCount \
-                dismissesStaleReviews \
-                requiresCodeOwnerReviews \
-              } \
+              ...brancheData \
             } \
+            %branches% \
           } \
         } \
       } \
@@ -105,6 +113,16 @@ script "js_github_query", type: "javascript" do
       remaining \
       resetAt \
     } \
+  } \
+  fragment brancheData on Ref { \
+    name \
+    branchProtectionRule { \
+      pattern \
+      isAdminEnforced \
+      requiredApprovingReviewCount \
+      dismissesStaleReviews \
+      requiresCodeOwnerReviews \
+    } \
   }';
 
   var org_names_string = "";
@@ -112,7 +130,15 @@ script "js_github_query", type: "javascript" do
     org_names_string = org_names_string + " org:" + org;
   });
 
-  var result = [query.replace("%orgNames%", org_names_string)]
+  var branches_string = " ";
+
+  var branch_template = ' %branch%: refs(first: 100, refPrefix: "refs/heads/", query: "%branch%") { nodes { ...brancheData } } ';
+
+  _.each(branches, function(branch) {
+    branches_string = branches_string + branch_template.replace("%branch%", branch).replace("%branch%", branch);
+  });
+
+  var result = [query.replace("%orgNames%", org_names_string).replace("%branches%", branches_string)]
 
 EOS
 end
@@ -131,28 +157,55 @@ datasource "ds_github_repos" do
     encoding "json"
     collect jmes_path(response, "data.search.edges[*]") do
       field "id", jmes_path(col_item, "node.id")
-      field "repo_name", jmes_path(col_item, "node.name")
+      field "name", jmes_path(col_item, "node.name")
       field "full_name", jmes_path(col_item, "node.nameWithOwner")
       field "default_branch", jmes_path(col_item, "node.defaultBranchRef.name")
       field "branch_protection_rule", jmes_path(col_item, "node.defaultBranchRef.branchProtectionRule")
-      field "repo_org", jmes_path(col_item, "node.owner.login")
+      field "owner", jmes_path(col_item, "node.owner.login")
+      field "full_data", jmes_path(col_item, "node")
     end
   end
 end
 
 datasource "ds_invalid_repo_branches" do
-    run_script $js_invalid_repo_branches, $ds_github_repos, $param_whitelist
+    run_script $js_invalid_repo_branches, $ds_github_repos, $param_whitelist, $param_branches, $param_include_default_branch
 end
 
 script "js_invalid_repo_branches", type: "javascript" do
-    parameters "repos", "param_whitelist"
-    result "invalid_repos"
+    parameters "repos", "param_whitelist", "branches", "include_default_branch"
+    result "invalid_repos_branches"
     code <<-EOS
-var invalid_repos = [];
+var invalid_repos_branches = [];
 
 _.each(repos, function(repo) {
-  if(!_.contains(param_whitelist, repo.full_name) && repo.branch_protection_rule == null) {
-    invalid_repos.push(repo);
+  if(!_.contains(param_whitelist, repo.full_name)) {
+    if (include_default_branch == "true" && repo.default_branch != null && repo.branch_protection_rule == null) {
+      var i_repo = {};
+      i_repo.id = repo.id;
+      i_repo.full_name = repo.full_name;
+      i_repo.branch_name = repo.default_branch;
+      i_repo.repo_org = repo.owner;
+      i_repo.repo_name = repo.name;
+
+      invalid_repos_branches.push(i_repo);
+    }
+
+    _.each(branches, function(branch) {
+      if(branch != repo.default_branch) {
+        _.each(repo.full_data[branch].nodes, function(item) {
+          if(item.name == branch && item.branchProtectionRule == null) {
+            var i_repo = {};
+            i_repo.id = repo.id;
+            i_repo.full_name = repo.full_name;
+            i_repo.branch_name = branch;
+            i_repo.repo_org = repo.owner;
+            i_repo.repo_name = repo.name;
+
+            invalid_repos_branches.push(i_repo);
+          }
+        });
+      }
+    });
   }
 });
 
@@ -172,8 +225,8 @@ policy "invalid_repos" do
       field "full_name" do
         label "Organization / Repository"
       end
-      field "default_branch" do
-        label "Unprotected default branch"
+      field "branch_name" do
+        label "Unprotected Branch"
       end
       field "id" do
         label "Id"

--- a/compliance/github/repository_branch_protection/repository_branch_protection.pt
+++ b/compliance/github/repository_branch_protection/repository_branch_protection.pt
@@ -1,6 +1,6 @@
 name "GitHub.com Repository Branches without Protection"
 rs_pt_ver 20180301
-short_description "Gets the repositories under a GitHub.com Organization and creates incidents for any that do not have protection enabled for default branch.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/github/repository_branch_protection) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+short_description "Gets the repositories under a list of GitHub.com Organizations and creates incidents for any that do not have protection enabled for their default branch.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/github/repository_branch_protection) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
 long_description ""
 severity "medium"
 category "Compliance"

--- a/compliance/github/repository_branch_protection/repository_branch_protection.pt
+++ b/compliance/github/repository_branch_protection/repository_branch_protection.pt
@@ -1,6 +1,6 @@
 name "GitHub.com Repository Branches without Protection"
 rs_pt_ver 20180301
-short_description "Gets the repositories + branches under a GitHub.com Organization and creates incidents for any that do not have protection enabled.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/github/repository_branch_protection) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+short_description "Gets the repositories under a GitHub.com Organization and creates incidents for any that do not have protection enabled for default branch.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/github/repository_branch_protection) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
 long_description ""
 severity "medium"
 category "Compliance"
@@ -19,12 +19,6 @@ end
 parameter "param_orgs" do
   type "list"
   label "Organizations on GitHub.com to scan"
-end
-
-parameter "param_branches" do
-  type "list"
-  label "Git branches that should be protected"
-  default ["master"]
 end
 
 parameter "param_whitelist" do
@@ -62,81 +56,106 @@ end
 
 pagination "github_pagination" do
   get_page_marker do
-    header "Link"
+    body_path jq(response, 'if .data.search.pageInfo.hasNextPage then "{ \"currentCursor\" :\"" + .data.search.pageInfo.endCursor + "\" }" else null end')
   end
   set_page_marker do
-    uri true
+    body_field "variables"
   end
 end
 
-datasource "ds_orgs_array" do
-  run_script $js_orgs_array, $param_orgs
+datasource "ds_github_query" do
+  run_script $js_github_query, $param_orgs
 end
-script "js_orgs_array", type: "javascript" do
-  parameters "param_orgs"
-  result "orgs_array"
+
+script "js_github_query", type: "javascript" do
+  parameters "orgNames"
+  result "result"
   code <<-EOS
-var orgs_array = param_orgs;
+  var query = 'query getRepositories($currentCursor: String) { \
+    search(query: "%orgNames% archived:false", type: REPOSITORY, first: 100, after: $currentCursor) { \
+      edges { \
+        node { \
+          ... on Repository { \
+            id \
+            name \
+            nameWithOwner \
+            owner { \
+              login \
+            } \
+            defaultBranchRef { \
+              name \
+              branchProtectionRule { \
+                isAdminEnforced \
+                requiredApprovingReviewCount \
+                dismissesStaleReviews \
+                requiresCodeOwnerReviews \
+              } \
+            } \
+          } \
+        } \
+      } \
+      pageInfo { \
+        endCursor \
+        hasNextPage \
+      } \
+    } \
+    rateLimit { \
+      limit \
+      cost \
+      remaining \
+      resetAt \
+    } \
+  }';
+
+  var org_names_string = "";
+  _.each(orgNames, function(org) {
+    org_names_string = org_names_string + " org:" + org;
+  });
+
+  var result = [query.replace("%orgNames%", org_names_string)]
+
 EOS
 end
 
-datasource "ds_orgs_repos" do
-  iterate $ds_orgs_array
+datasource "ds_github_repos" do
+  iterate $ds_github_query # always one item
   request do
     auth $auth_github
+    verb "POST"
     pagination $github_pagination
     host "api.github.com"
-    path join(["/orgs/",iter_item,"/repos"])
+    path "graphql"
+    body_field "query", iter_item
   end
   result do
     encoding "json"
-    collect jmes_path(response, "[*]") do
-      field "id", jmes_path(col_item, "id")
-      field "name", jmes_path(col_item, "name")
-      field "full_name", jmes_path(col_item, "full_name")
-      field "org", jmes_path(col_item, "owner.login")
-    end
-  end
-end
-
-datasource "ds_repos_branches" do
-  iterate $ds_orgs_repos
-  request do
-    auth $auth_github
-    pagination $github_pagination
-    host "api.github.com"
-    path join(["/repos/",val(iter_item,"org"),"/",val(iter_item,"name"),"/branches"])
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "[*]") do
-      field "id", jmes_path(iter_item, "id")
-      field "repo_name", jmes_path(iter_item, "name")
-      field "repo_org", jmes_path(iter_item, "org")
-      field "branch_name", jmes_path(col_item, "name")
-      field "branch_protected", jmes_path(col_item, "protected")
-      field "branch_protection", jmes_path(col_item, "protection")
+    collect jmes_path(response, "data.search.edges[*]") do
+      field "id", jmes_path(col_item, "node.id")
+      field "repo_name", jmes_path(col_item, "node.name")
+      field "full_name", jmes_path(col_item, "node.nameWithOwner")
+      field "default_branch", jmes_path(col_item, "node.defaultBranchRef.name")
+      field "branch_protection_rule", jmes_path(col_item, "node.defaultBranchRef.branchProtectionRule")
+      field "repo_org", jmes_path(col_item, "node.owner.login")
     end
   end
 end
 
 datasource "ds_invalid_repo_branches" do
-    run_script $js_invalid_repo_branches, $ds_repos_branches, $param_branches, $param_whitelist
+    run_script $js_invalid_repo_branches, $ds_github_repos, $param_whitelist
 end
 
 script "js_invalid_repo_branches", type: "javascript" do
-    parameters "repos_branches", "param_branches", "param_whitelist"
-    result "invalid_repo_branches"
+    parameters "repos", "param_whitelist"
+    result "invalid_repos"
     code <<-EOS
-var invalid_repo_branches = [];
-for (var index = 0; index < repos_branches.length; index++) {
-  var branch = repos_branches[index];
-  // check if branch is in param_branches and if its protected
-  if( _.contains(param_branches, branch.branch_name) && !_.contains(param_whitelist, branch.repo_org+"/"+branch.repo_name) && branch.branch_protected != true){
-    branch["fullOrganizationName"] = "["+branch.repo_org+"/"+branch.repo_name+"](https://github.com/"+branch.repo_org+"/"+branch.repo_name+"/settings/branches)"
-    invalid_repo_branches.push(branch);
+var invalid_repos = [];
+
+_.each(repos, function(repo) {
+  if(!_.contains(param_whitelist, repo.full_name) && repo.branch_protection_rule == null) {
+    invalid_repos.push(repo);
   }
-}
+});
+
 EOS
 end
 
@@ -150,11 +169,11 @@ policy "invalid_repos" do
     #### Policy Branches: {{  parameters.param_branches }}
     export do
       resource_level true
-      field "fullOrganizationName" do
+      field "full_name" do
         label "Organization / Repository"
       end
-      field "branch_name" do
-        label "Unprotected Branch"
+      field "default_branch" do
+        label "Unprotected default branch"
       end
       field "id" do
         label "Id"
@@ -185,12 +204,12 @@ end
 
 define github_repos_branch_add_protection($data, $param_enforce_admins, $param_required_pull_request_reviews) do
   foreach $item in $data do
-    task_label( join(["Updating branch protection for ",$item['repo_org'],"/",$item['repo_name'],":",$item['branch_name']]) )
-    call github_repo_branch_protection_update($item['repo_org'],$item['repo_name'],$item['branch_name'],$param_enforce_admins, $param_required_pull_request_reviews) retrieve $github_repo_branch_protection_update_response
+    task_label( join(["Updating branch protection for ",$item['repo_org'],"/",$item['repo_name'],":",$item['default_branch']]) )
+    call github_repo_branch_protection_update($item['repo_org'],$item['repo_name'],$item['default_branch'],$param_enforce_admins, $param_required_pull_request_reviews) retrieve $github_repo_branch_protection_update_response
   end
 end
 
-define github_repo_branch_protection_update($owner, $repo, $branch, $enforce_admins, $required_pull_request_reviews) return $response do 
+define github_repo_branch_protection_update($owner, $repo, $branch, $enforce_admins, $required_pull_request_reviews) return $response do
   $enforce_admins = to_b($enforce_admins)
   if $required_pull_request_reviews == "null"
     $required_pull_request_reviews = null


### PR DESCRIPTION
### Description

Current issues:

- **GitHub Api Rate limit**: Running current version every hour or less will consume too many calls from the limit.
- **Default Branch**: In the current version is not possible to protect the default branch, it only accept a list of branches which can be different from the real default branch.
- **Minimum configuration**: Current version doesn't change the protection configuration if it doesn't match the parameters, it only checks if there is a branch protection

This PR is fixing the top two issues by using GitHub GraphQL API to grab the data with less api calls (e.g.: 6 calls for flexera with 550 repos) and also to check the default branch instead of using a branch list.

### Issues Resolved

Mentioned above.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
