### PR TITLE
AWS Unused Volumes: Sleep more to be friendly to CWF

### DIFF
--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.16
+
+- Increase the sleep time between calls to AWS for snapshot status in order to decrease the likelihood of hitting
+  a Cloud Workflow event limit
+
 ## v2.15
 
 - Improve error handling and debug logging so that errors from taking action are actually surfaced

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -5,7 +5,7 @@ short_description "Checks for unused volumes with no read/write operations perfo
 category "Cost"
 severity "low"
 info(
-  version: "2.15",
+  version: "2.16",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes"
@@ -813,7 +813,7 @@ define create_volumes_snapshot($item, $errors) return $status_code, $errors do
       $condition_check = "completed"
 
       while $condition_check !~ $snapshot_status do
-        sleep(2)
+        sleep(30)
         call get_snapshot_status(to_s($snapshotId), []) retrieve $status, $snapshot_errors
         $snapshot_status = $status
 


### PR DESCRIPTION
### Description

- Increase the sleep time between calls to AWS for snapshot status in order to decrease the likelihood of hitting a Cloud Workflow event limit

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
