### PR TITLE
POL-417: top 10 cost categories not just for current month.

### DIFF
--- a/cost/scheduled_reports/CHANGELOG.md
+++ b/cost/scheduled_reports/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.24
+
+- Fixed issue with top 10 cost categories when there is no data yet for current month.
+
 ## v1.23
 
 - Fixed markdown block.

--- a/cost/scheduled_reports/scheduled_report.pt
+++ b/cost/scheduled_reports/scheduled_report.pt
@@ -20,7 +20,7 @@ category "Cost"
 default_frequency "monthly"
 tenancy "single"
 info(
-  version: "1.23",
+  version: "1.24",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -907,7 +907,7 @@ script "js_generate_report", type: "javascript" do
     var topValues;
     var categories=[];
     var otherData=[];
-    topValues = _.sortBy(_.filter(collated_data, function(x){ return (x.yearMonth==currentMonth &&  x.category != "")}),'cost').reverse();
+    topValues = _.sortBy(_.filter(collated_data, function(x){ return (x.category != "")}),'cost').reverse();
     _.each(topValues, function(topValue){
       if(!_.contains(categories, topValue.category) && _.size(categories) < 10){
         categories.push(topValue.category);


### PR DESCRIPTION
### Description

The scheduled report policy template was building a list of top 10 values (categories) for the considered dimension by cost, but based on the current month only, not all months in the data. If there was no data for the current months, that top 10 list would be empty => everything ended up lumped into the "Other" bucket.

The fix is to considered all the data to build that top 10 list by cost, and not just the current month.

### Issues Resolved

https://jira.flexera.com/browse/POL-417

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
