### PR TITLE
IND-4243: Policies can't log to CM audit entries in EU, so disable that (e.g. via param).

### DIFF
--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.5
+
+- Removed the sys_log function as it was not used
+
 ## v2.4
 
 - Get the type from the resource object, and check whether it supports tags

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -5,7 +5,7 @@ short_description "Find all Azure resources missing any of the user provided tag
 category "Compliance"
 severity "low"
 info(
-   version: "2.4",
+   version: "2.5",
    provider: "Azure",
    service: "",
    policy_set: "Untagged Resources"
@@ -349,16 +349,4 @@ define handle_error($response) do
   else
     $_error_behavior = "raise"
   end
-end
-
-define sys_log($subject, $detail) do
-
-    rs_cm.audit_entries.create(
-      notify: "None",
-      audit_entry: {
-        auditee_href: @@account,
-        summary: $subject,
-        detail: $detail
-      }
-    )
 end


### PR DESCRIPTION
### Description

In the Flexera EU application, no CM will be available; any (cost/compliance) policy that we want to roll out there and is currently logging to CM Audit Entries needs to be revised. For instance, add a param to switch those logs on/off (default: off).

* compliance/azure/azure_untagged_resources/untagged_resources.pt: template had a `sys_log` function (to log to CM audit entries) that is actually not used, so I just removed it.

### Issues Resolved

See: https://jira.flexera.com/browse/IND-4243

### Contribution Check List

- [ ] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
