### PR TITLE
POL-425: Drop namespace from resource type when looking up API versions.

### DIFF
--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6
+
+- Drop namespace from resource type when looking up supported API versions
+
 ## v2.5
 
 - Removed the sys_log function as it was not used

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -5,7 +5,7 @@ short_description "Find all Azure resources missing any of the user provided tag
 category "Compliance"
 severity "low"
 info(
-   version: "2.5",
+   version: "2.6",
    provider: "Azure",
    service: "",
    policy_set: "Untagged Resources"
@@ -305,7 +305,8 @@ define tag_resources($data, $param_tags_to_add) return $all_responses do
     $$log << "ID: "+$item["id"]
     $namespace = $item["namespace"]
     $$log << "Namespace: "+$namespace
-    $resource_type = $item["resource_type"]
+    # Drop the provider's namespace from the resource type
+    $resource_type = join(split($item["resource_type"], "/")[1..], "/")
     $$log << "Resource Type: "+$resource_type
     $namespace_obj = select($providers_array, {"namespace": $namespace})
     if $namespace_obj == []


### PR DESCRIPTION
### Description

In the "Tag Resources" action, drop the provider's namespace from the resource type when looking up supported API versions,
since the resource types in the provider object don't have that namespace prepended.

### Issues Resolved

https://jira.flexera.com/browse/POL-425

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
