### PR TITLE
IND-4219: Fixed HERE doc markdown alignment.

### DIFF
--- a/cost/budget_alerts/CHANGELOG.md
+++ b/cost/budget_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.15
+
+- Fixed markdown alignment in HERE doc, which was causing the conversion to HTML in the email to fail.
+
 ## v1.14
 
 - Modified escalation label and description for consistency

--- a/cost/budget_alerts/budget_alert.pt
+++ b/cost/budget_alerts/budget_alert.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "1.14",
+  version: "1.15",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -539,12 +539,12 @@ policy "budget_alert" do
     # ignore changes to the monthly spend and runrate, since those will change constantly
     hash_exclude "actual", "runrate", "total"
     detail_template <<-EOS
-      # Budget Exceeded
-      ### Cost Metric: {{ parameters.param_cost_metric }}
-      ### Budget Alert Type: {{ parameters.param_type }}
-      ### Monthly Spend for {{ data.monthYear }}
-      ![Spending Overview Chart](https://image-charts.com/chart?{{ data.chartType }}&{{ data.chartData }}&{{ data.chartSize }}&{{ data.chartImage }}&{{ data.chartColor }}&{{ data.chartLebel }}&{{ data.chartYAxisLebel }}&{{ data.chartYAxis }}&{{ data.chartLebelPosition }}&{{data.chartDataAutoScale}}&{{data.chartDataValue}}&{{ data.chartTitle }}"Actual v. Monthly Cost Report")
-    EOS
+# Budget Exceeded
+### Cost Metric: {{ parameters.param_cost_metric }}
+### Budget Alert Type: {{ parameters.param_type }}
+### Monthly Spend for {{ data.monthYear }}
+![Spending Overview Chart](https://image-charts.com/chart?{{ data.chartType }}&{{ data.chartData }}&{{ data.chartSize }}&{{ data.chartImage }}&{{ data.chartColor }}&{{ data.chartLebel }}&{{ data.chartYAxisLebel }}&{{ data.chartYAxis }}&{{ data.chartLebelPosition }}&{{data.chartDataAutoScale}}&{{data.chartDataValue}}&{{ data.chartTitle }}"Actual v. Monthly Cost Report")
+EOS
     escalate $esc_budget_alert
     check lt(val(data,"total"),$param_monthly_budget)
     export "reportData" do


### PR DESCRIPTION
### Description

Fixed the alignment in the HERE doc for the markdown that gets added to the email.
The extra whitespace at the start of lines was causing the conversion to HTML to fail for the email.

### Issues Resolved

https://jira.flexera.com/browse/IND-4219

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
