### PR TITLE
POL-427: for metrics, right api-version, and one-day interval.

### DIFF
--- a/cost/azure/idle_compute_instances/CHANGELOG.md
+++ b/cost/azure/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.8
+
+- Use the right API version to get the monitor/metrics, and use the biggest interval (ie "P1D", ie one-day)
+
 ## v2.7
 
 - Updated policy to fetch cost details for multiple subscription ids from Optima

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Cost"
 severity "low"
 info(
-  version: "2.7",
+  version: "2.8",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle Compute Instances"
@@ -135,8 +135,9 @@ datasource "ds_azure_instance_performance" do
     pagination $azure_pagination
     host "management.azure.com"
     path join(["/subscriptions/", val(iter_item,"subscriptionId"), "/resourceGroups/", val(iter_item,"rg"), "/providers/Microsoft.Compute/virtualMachines/",val(iter_item,"name"),"/providers/microsoft.insights/metrics"])
-    query "api-version","2016-09-01"
+    query "api-version","2018-01-01"
     query "timespan","P30D"
+    query "interval", "P1D"
     header "User-Agent", "RS Policies"
     ignore_status [404]
   end 
@@ -150,7 +151,7 @@ datasource "ds_azure_instance_performance" do
 	field "subscriptionId",val(iter_item,"subscriptionId")
     field "subscriptionName",val(iter_item,"subscriptionName")
     field "averages" do
-      collect jmes_path(response,"value[].data[]") do
+      collect jmes_path(response,"value[].timeseries[].data[]") do
         field "average", jmes_path(col_item,"average")
       end
     end


### PR DESCRIPTION
### Description

When retrieving the Monitor/Metrics, use the right API version, and the biggest possible interval to minimise the number of data points (that's one day, ie "P1D" in ISO 8601 duration notation).

### Issues Resolved

https://jira.flexera.com/browse/POL-427

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
