### PR TITLE
Initial release AHUB for SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Please contact sales@flexera.com to learn more.
 
 - [Azure Hybrid Use Benefit](./cost/azure/hybrid_use_benefit/)
 - [Azure Hybrid Use Benefit for Linux](./cost/azure/hybrid_use_benefit_linux/)
+- [Azure Hybrid Use Benefit for SQL](./cost/azure/hybrid_use_benefit_sql/)
 - [Azure Idle Compute Instances](./cost/azure/idle_compute_instances/)
 - [Azure Inefficient Instance Utilization using Log Analytics](./cost/azure/instances_log_analytics_utilization/)
 - [Azure Expiring Reserved Instances](./cost/azure/reserved_instances/expiration)

--- a/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0
+
+- Initial release

--- a/cost/azure/hybrid_use_benefit_sql/README.md
+++ b/cost/azure/hybrid_use_benefit_sql/README.md
@@ -1,0 +1,48 @@
+# Azure Hybrid Use Benefit Policy for SQL
+
+## What it does
+
+This Policy Template is used to automatically apply the Azure Hybrid Use Benefit (AHUB) to all eligible SQL instances in an Azure Subscription.
+
+## Functional Details
+
+- The policy identifies all SQL databases in Azure that are not currently using [Azure Hybrid Use Benefit](https://azure.microsoft.com/en-us/pricing/hybrid-benefit/). These can be SQL Virtual Machines, SQL Databases or SQL Managed Instances. It raises an incident for all applicable instances not currently using AHUB, which once approved, will enable AHUB on all identified instances.
+- The Exclusion Tag parameter is a string value. Supply the Tag Key only. Tag Values are not analyzed and therefore are not need. If the exclusion tag key is used on an Instance, that Instance is presumed to be exempt from this policy.
+- This policy does not track licenses or availability. It is your responsibility to ensure you are not under licensed.
+
+## Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Exclusion Tag Key* - an Azure-native instance tag to ignore instances that are not using AHUB. Only supply the tag key. The policy assumes that the tag value is irrelevant.
+- *Email addresses* - A list of email addresses of the recipients you wish to notify
+- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
+
+Please note that the "*Automatic Actions*" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action. For example, if a user selects the "Hybrid use benefit for SQL" action while applying the policy, hybrid use benefit will be applied to the eligible instances.
+
+## Prerequisites
+
+This policy uses [credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+
+### Credential configuration
+
+For administrators [creating and managing credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) to use with this policy, the following information is needed:
+
+Provider tag value to match this policy: `azure_rm`
+
+Required permissions in the provider:
+
+- Microsoft.SqlVirtualMachine/sqlVirtualMachines/read
+- Microsoft.SqlVirtualMachine/sqlVirtualMachines/write
+- Microsoft.Sql/servers/read
+- Microsoft.Sql/servers/write
+- Microsoft.Sql/managedInstances/read
+- Microsoft.Sql/managedInstances/write
+
+## Supported Clouds
+
+- Azure Resource Manager
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -1,0 +1,447 @@
+name "Azure Hybrid Use Benefit for SQL"
+rs_pt_ver 20180301
+type "policy"
+short_description "Identifies SQL instances eligible for Azure Hybrid Use Benefit.  See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/azure/hybrid_use_benefit) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
+long_description ""
+severity "low"
+category "Cost"
+info(
+  version: "1.0",
+  provider: "Azure",
+  service: "compute",
+  policy_set: ""
+)
+
+#############
+# Parameters
+#############
+
+parameter "param_exclusion_tag_key" do
+  category "User Inputs"
+  label "Exclusion Tag Key"
+  description "Azure-native instance tag to ignore instances that are not using AHUB/BYOL. Only supply the tag key. The policy assumes that the tag value is irrelevant."
+  type "string"
+  default "exclude_ahub"
+end
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses of the recipients you wish to notify"
+end
+
+parameter "param_automatic_action" do
+  type "list"
+  label "Automatic Actions"
+  description "When this value is set, this policy will automatically take the selected action(s)"
+  allowed_values "Hybrid use benefit for SQL"
+end
+
+#################
+# Authentication
+#################
+
+credentials "azure_auth" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Resource Manager Credential from the list."
+  tags "provider=azure_rm"
+end
+
+#############
+# Pagination
+#############
+
+pagination "azure_pagination" do
+  get_page_marker do
+    body_path "nextLink"
+  end
+  set_page_marker do
+    uri true
+  end
+end
+
+##############
+# Datasources
+##############
+
+datasource "ds_subscriptions" do
+  request do
+    auth $azure_auth
+    pagination $azure_pagination
+    host "management.azure.com"
+    path "/subscriptions/"
+    query "api-version","2019-06-01"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "subscriptionId", jmes_path(col_item,"subscriptionId")
+      field "subscriptionName", jmes_path(col_item,"displayName")
+    end
+  end
+end
+
+datasource "sql_virtualmachines" do
+  iterate $ds_subscriptions
+    request do
+      auth $azure_auth
+      pagination $azure_pagination
+      host "management.azure.com"
+      path join(["/subscriptions/", val(iter_item,"subscriptionId"), "/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines"])
+      query "api-version","2017-03-01-preview"
+    end
+    result do
+      encoding "json"
+      collect jmes_path(response, "value") do
+	      field "subscriptionName", val(iter_item,"subscriptionName")
+        field "id", jmes_path(col_item,"id")
+        field "vmid", jmes_path(col_item,"properties.virtualMachineResourceId")
+        field "name", jmes_path(col_item,"name")
+        field "location", jmes_path(col_item,"location")
+        field "licenseType", jmes_path(col_item,"properties.sqlServerLicenseType")
+        field "imageSku", jmes_path(col_item,"properties.sqlImageSku")
+        field "imageOffer", jmes_path(col_item,"properties.sqlImageOffer")
+        field "type", get(1, split(jmes_path(col_item,"type"), "/"))
+        field "tags", jmes_path(col_item,"tags")
+      end
+    end
+end
+
+# For SQL databases running provisioned database applicable, serverless SQL databases are not eligible to AHUB
+datasource "sql_dbserver" do
+  iterate $ds_subscriptions
+    request do
+      auth $azure_auth
+      pagination $azure_pagination
+      host "management.azure.com"
+      path join(["/subscriptions/", val(iter_item,"subscriptionId"), "/providers/Microsoft.Sql/servers"])
+      query "api-version","2019-06-01-preview"
+    end
+    result do
+      encoding "json"
+      collect jmes_path(response, "value") do
+	      field "subscriptionName", val(iter_item,"subscriptionName")
+        field "resourceGroup", get(4, split(jmes_path(col_item,"id"), "/"))
+        field "dbserverId", jmes_path(col_item,"id")
+        field "dbserverName", jmes_path(col_item,"name")
+        field "type", jmes_path(col_item,"type")
+        field "tags", jmes_path(col_item,"tags")
+      end
+    end
+end
+
+datasource "sql_databases" do
+  iterate $sql_dbserver
+    request do
+      auth $azure_auth
+      pagination $azure_pagination
+      host "management.azure.com"
+      path join([val(iter_item,"dbserverId"),"/databases"])
+      query "api-version", "2020-08-01-preview"
+    end
+    result do
+      encoding "json"
+      collect jmes_path(response, "value") do
+        field "subscriptionName", val(iter_item,"subscriptionName")
+        field "resourceGroup", val(iter_item,"resourceGroup")
+        field "id", jmes_path(col_item,"id")
+        field "licenseType", jmes_path(col_item,"properties.licenseType")
+        field "vCores", jmes_path(col_item,"properties.currentSku.capacity")
+        field "location", jmes_path(col_item,"location")
+        field "tags", jmes_path(col_item,"tags")
+        field "name", jmes_path(col_item,"name")
+        field "kind", jmes_path(col_item,"kind")
+        field "type", get(2, split(jmes_path(col_item,"type"), "/"))
+      end
+    end
+end
+
+datasource "sql_managed_instances" do
+  iterate $ds_subscriptions
+    request do
+      auth $azure_auth
+      pagination $azure_pagination
+      host "management.azure.com"
+      path join(["/subscriptions/", val(iter_item,"subscriptionId"), "/providers/Microsoft.Sql/managedInstances"])
+      query "api-version","2020-11-01-preview"
+    end
+    result do
+      encoding "json"
+      collect jmes_path(response, "value") do
+        field "subscriptionName", val(iter_item,"subscriptionName")
+        field "resourceGroup", get(4, split(jmes_path(col_item,"id"), "/"))
+        field "id", jmes_path(col_item,"id")
+        field "licenseType", jmes_path(col_item,"properties.licenseType")
+        field "vCores", jmes_path(col_item,"properties.vCores")
+        field "location", jmes_path(col_item,"location")
+        field "tags", jmes_path(col_item,"tags")
+        field "name", jmes_path(col_item,"name")
+        field "type", get(1, split(jmes_path(col_item,"type"), "/"))
+      end
+    end
+end
+
+
+datasource "filtered_instances" do
+  run_script $js_filtered_instances, $sql_virtualmachines, $sql_databases, $sql_managed_instances, $param_exclusion_tag_key
+end
+
+##########
+# Scripts
+##########
+
+script "js_filtered_instances", type: "javascript" do
+  parameters "sql_virtualmachines", "sql_databases", "sql_managed_instances", "exclusion_tag"
+  result "result"
+  code <<-EOS
+  var result = [];
+    //SQL Virtualmachines
+      _.each(sql_virtualmachines, function(virtualmachine){
+        if (_.has(virtualmachine.tags, exclusion_tag)) {
+        } else {
+            var resourceGroup = virtualmachine.id.split('/')[4];
+            var tags = JSON.stringify(virtualmachine["tags"]);
+            var ahub = "N/A"
+            if (virtualmachine.licenseType === "AHUB") {
+                ahub = "Yes"
+              } else {
+                ahub = "No"
+              }
+
+            result.push({
+              subscriptionName: virtualmachine["subscriptionName"],
+              id: virtualmachine["id"],
+              vmid: virtualmachine["vmid"],
+              name: virtualmachine["name"],
+              resourceGroup: resourceGroup,
+              location: virtualmachine["location"],
+              ahub: ahub,
+              type: virtualmachine["type"],
+              imageOffer: virtualmachine["imageOffer"],
+              imageSku: virtualmachine["imageSku"]
+              licenseType: virtualmachine["licenseType"],
+              tags: tags
+            })
+          }
+      })
+
+    //SQL databases
+    _.each(sql_databases, function(database){
+      var version = database.kind.split(',')[3]
+      if (_.isNull(database.tags) || _.has(database.tags, exclusion_tag)) {
+      } else {
+          if (database.licenseType === "None" || _.isUndefined(database.licenseType)) {
+          } else {
+              if (version !== "serverless" && database.skuName !== "System") {
+                var resourceGroup = database.id.split('/')[4];
+                var tags = JSON.stringify(database["tags"]);
+                var ahub = "N/A";
+                if (database.licenseType === "BasePrice") {
+                  ahub = "Yes"
+                } else {
+                  ahub = "No"
+                  }
+                console.log(database["name"], "AHUB: ", ahub)
+                result.push({
+                  subscriptionName: database["subscriptionName"],
+                  id: database["id"],
+                  name: database["name"],
+                  resourceGroup: database["resourceGroup"],
+                  location: database["location"],
+                  ahub: ahub,
+                  licenseType: database["licenseType"],
+                  vCores: database["vCores"]
+                  type: database["type"],
+                  tags: tags
+                })
+              }
+            }
+        }
+    })
+
+    //SQL Managed Instances
+    _.each(sql_managed_instances, function(instance){
+      if (_.has(instance.tags, exclusion_tag)) {
+      } else {
+          if (instance.licenseType === "None" || _.isUndefined(instance.licenseType)) {
+          } else {
+              var tags = JSON.stringify(instance["tags"]);
+              var ahub = "N/A"
+              if (instance.licenseType === "BasePrice") {
+                ahub = "Yes"
+              } else {
+                ahub = "No"
+              }
+              result.push({
+                subscriptionName: instance["subscriptionName"],
+                id: instance["id"],
+                name: instance["name"],
+                resourceGroup: instance["resourceGroup"],
+                location: instance["location"],
+                ahub: ahub,
+                licenseType: instance["licenseType"],
+                vCores: instance["vCores"]
+                type: instance["type"],
+                tags: tags
+              })
+            }
+        }
+    })
+
+    result = _.sortBy(result, 'subscriptionName');
+    result = _.sortBy(result, 'location');
+    result = _.sortBy(result, 'type');
+  EOS
+end
+
+##########
+# Policy
+##########
+
+policy 'azure_sql_ahub' do
+  validate_each $filtered_instances do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Instances Not Using Azure Hybrid Use Benefit for SQL"
+    escalate $email
+    escalate $license_sqlahub
+    check eq(val(item,"ahub"),"Yes")
+    export do
+      resource_level true
+      field "subscriptionName" do
+        label "Subscription Name"
+      end
+      field "name" do
+        label "Instance Name"
+      end
+      field "location" do
+        label "Location"
+      end
+      field "resourceGroup" do
+        label "Resource Group"
+      end
+      field "type" do
+        label "SQL Type"
+      end
+      field "vCores" do
+        label "vCores"
+      end
+      field "licenseType" do
+        label "Current License"
+      end
+      field "ahub" do
+        label "AHUB"
+      end
+      field "imageSku" do
+        label "Edition"
+      end
+      field "imageOffer" do
+        label "Version/VM OS"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "id" do
+        label "Id"
+      end
+      field "vmid" do
+        label "VirtualMachineResourceId"
+      end
+    end
+  end
+end
+
+##############
+# Escalations
+##############
+
+escalation "email" do
+  automatic true
+  label "Send Email"
+  description "Send Incident email"
+  email $param_email
+end
+
+escalation "license_sqlahub" do
+  automatic contains($param_automatic_action, "Hybrid Use Benefit for SQL")
+  label "Approve AHUB for SQL"
+  description "Approve escalation to apply Hybrid Use Benefit for SQL"
+  run "license_sqlahub", data
+end
+
+##################
+# Cloud Workflow
+##################
+
+define license_sqlahub($data) return $all_responses do
+  $all_responses = []
+  foreach $item in $data do
+    sub on_error: skip do
+      if ($item["type"] == "sqlVirtualMachines")
+        $update_inst_response = http_request(
+	      auth: $$azure_auth,
+          verb: "put",
+          host: "management.azure.com",
+          https: true,
+          href: $item["id"],
+          query_strings: {
+            "api-version": "2017-03-01-preview"
+          },
+          headers: {
+            "cache-control": "no-cache",
+            "content-type": "application/json"
+          },
+          body: {
+            "location": $item['location'],
+            "properties": {
+              "virtualMachineResourceId": $item['vmid'],
+              "sqlServerLicenseType": "AHUB"
+            }
+          }
+        )
+        $all_responses << $update_inst_response
+      elsif ($item["type"] == "databases")
+        $update_inst_response = http_request(
+	      auth: $$azure_auth,
+          verb: "patch",
+          host: "management.azure.com",
+          https: true,
+          href: $item["id"],
+          query_strings: {
+            "api-version": "2020-11-01-preview"
+          },
+          headers: {
+            "cache-control": "no-cache",
+            "content-type": "application/json"
+          },
+          body: {
+            "properties": {
+              "licenseType": "BasePrice"
+            }
+          }
+        )
+        $all_responses << $update_inst_response
+      elsif ($item["type"] == "managedInstances")
+        $update_inst_response = http_request(
+        auth: $$azure_auth,
+          verb: "patch",
+          host: "management.azure.com",
+          https: true,
+          href: $item["id"],
+          query_strings: {
+            "api-version": "2020-11-01-preview"
+          },
+          headers: {
+            "cache-control": "no-cache",
+            "content-type": "application/json"
+          },
+          body: {
+            "properties": {
+              "licenseType": "BasePrice"
+            }
+          }
+        )
+        $all_responses << $update_inst_response
+      end
+    end
+  end
+end


### PR DESCRIPTION
Initial release for an AHUB for SQL policy

### Description

This is a new policy for checking eligible SQL instances (SQL VM, SQL DB and SQL Managed Instance) in Azure for using the AHUB benefit for SQL. After identification AHUB can be automatically applied on selected instances.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
