### PR TITLE
CMLS-9 POL-418: ensure >= 1 mo cost data retrieved

### DIFF
--- a/cost/superseded_instance/CHANGELOG.md
+++ b/cost/superseded_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.12
+
+- Ensure at least a month worth of costs are retrieved
+
 ## v1.11
 
 - Fixed cloud account vendor URL, and use name instead of id

--- a/cost/superseded_instance/superseded_instance.pt
+++ b/cost/superseded_instance/superseded_instance.pt
@@ -8,7 +8,7 @@ severity "low"
 default_frequency "daily"
 tenancy "single"
 info(
-  version: "1.11",
+  version: "1.12",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -148,6 +148,8 @@ script "js_new_costs_request", type: "javascript" do
   result "request"
   code <<-EOS
     var date = new Date();
+    // Make sure we get at least a month worth of costs
+    date.setMonth(date.getMonth()-1);
     var year = date.getUTCFullYear();
 	var month =  (date.getUTCMonth()==11)?1:2 + date.getUTCMonth();
 


### PR DESCRIPTION
### Description

Using the current month to pull cost fails to pick up enough (or any) data at the beginning of the month: make sure at least one month of costs is retrieved to make sure we have a workable dataset.

### Issues Resolved

https://jira.flexera.com/browse/CMLS-9 

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
