### PR TITLE
CMLS-26 CMLS-27: Use OAuth2 FlexeraOne creds in EU region, and use rs_optima_host

### DIFF
--- a/cost/aws/reserved_instances/report_by_bc/CHANGELOG.md
+++ b/cost/aws/reserved_instances/report_by_bc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.7
+
+- Use rs_optima_host instead of hardcoded hostname
+
 ## v1.6
 
 - Added default_frequency "daily"

--- a/cost/aws/reserved_instances/report_by_bc/ri_report_by_bc.pt
+++ b/cost/aws/reserved_instances/report_by_bc/ri_report_by_bc.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "1.6",
+  version: "1.7",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -24,12 +24,17 @@ parameter "param_bc" do
   type "string"
 end
 
-auth "auth_rs", type: "rightscale"
+credentials "auth_rs" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select FlexeraOne OAuth2 credentials"
+  tags "provider=flexera"
+end
 
 datasource "reserved_instances" do
   request do
     auth $auth_rs
-    host "optima.rightscale.com"
+    host rs_optima_host
     path join(["/reserved_instances/orgs/",rs_org_id,"/clouds/aws"])
   end
   result do

--- a/cost/azure/reserved_instances/expiration/azure_reserved_instance_expiration.pt
+++ b/cost/azure/reserved_instances/expiration/azure_reserved_instance_expiration.pt
@@ -42,7 +42,12 @@ end
 # Authentication
 ###############################################################################
 
-auth "auth_rs", type: "rightscale"
+credentials "auth_rs" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select FlexeraOne OAuth2 credentials"
+  tags "provider=flexera"
+end
 
 ###############################################################################
 # Pagination

--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3
+
+- "Delete schedule" action now removes the "schedule", "next_start" and "next_stop" tags
+
 ## v2.2
 
 - Added default_frequency "daily"

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.2",
+  version: "2.3",
   provider: "Azure",
   service: "Compute",
   policy_set:"Schedule Instance"
@@ -87,7 +87,7 @@ datasource "ds_subscriptions" do
   end
 end
 
-#get all virtual machines 
+#get all virtual machines
 datasource "ds_azure_virtualmachines" do
   iterate $ds_subscriptions
   request do
@@ -132,7 +132,7 @@ datasource "ds_azure_instances" do
     field "rg", val(iter_item,"rg")
     field "name", val(iter_item,"name")
     field "location", val(iter_item, "location")
-    field "tags", val(iter_item,"tags")	     
+    field "tags", val(iter_item,"tags")
     field "subscriptionId",val(iter_item,"subscriptionId")
     field "subscriptionName",val(iter_item,"subscriptionName")
   end
@@ -174,7 +174,7 @@ script "js_filter_instances", type: "javascript" do
         else if(prop== 'next_stop'){
           next_stop=new Date(instance.tags[prop]);
           next_stop_iso=next_stop.toISOString();
-        }	  
+        }
       }
       var resource_tags = JSON.stringify(instance.tags);
       var all_tags={};
@@ -195,7 +195,7 @@ script "js_filter_instances", type: "javascript" do
           "all_tags": resource_tags,
           "tags":all_tags,
           "next_start":next_start_iso,
-          "next_stop":next_stop_iso	
+          "next_stop":next_stop_iso
         })
       }
   results = _.sortBy(results, 'subscriptionName');
@@ -285,7 +285,7 @@ policy "policy_schedule_instance" do
       end
       field "rg" do
         label "Resource Group"
-      end  
+      end
       field "schedule" do
         label "Schedule"
       end
@@ -364,7 +364,7 @@ define schedule_instance($data) return $all_responses do
 
     $stoppable = /^(running|starting|deallocating|deallocated)$/
     $startable = /^(stopped|stopping|deallocating|deallocated)$/
-    call tag_resources($item, $item['schedule'], $next_start, $next_stop) retrieve $responses	
+    call tag_resources($item, $item['schedule'], $next_start, $next_stop) retrieve $responses
     if($window_active)
       if($item['state']=~$startable)
         call sys_log('> ' + $item['id'] + ': Starting ...', to_s($item))
@@ -451,26 +451,33 @@ define delete_schedule($data) return $all_responses do
   foreach $item in $data do
     call sys_log('> ' + $item['id'] + ': Deleting schedule Tag ...', to_s($item))
       $delete_tag = "delete"
-      call tag_resources($item, $delete_tag, $next_start, $next_stop) retrieve $response    
+      call tag_resources($item, $delete_tag, $next_start, $next_stop) retrieve $response
       $all_responses << $response
   end
 end
 
 define tag_resources($item, $param, $next_start, $next_stop) return $update_resource_response do
-   $$log = [] 
+   $$log = []
    $new_tags = {}
-   $new_tags = $item["tags"] 
-   if $param != "delete" 
+   $old_tags = $item["tags"]
+   if $param == "delete"
+      foreach $tag_key in keys($old_tags) do
+        if $tag_key != "next_start" && $tag_key != "next_stop" && $tag_key != "schedule"
+          $new_tags[$tag_key] = $old_tags[$tag_key]
+        end
+      end
+   else
+      $new_tags = $old_tags
       $new_tags["next_start"]= $next_start
       $new_tags["next_stop"]= $next_stop
       $new_tags["schedule"]= $param
    end
-   $$log << to_s($new_tags)	
+   $$log << to_s($new_tags)
    $$log << $next_start
-   $$log << $next_stop	
+   $$log << $next_stop
    $$log << $param
    call sys_log('all tags ', to_s($new_tags))
-   sub on_error: handle_error($update_resource_response) do 
+   sub on_error: handle_error($update_resource_response) do
       $update_resource_response = http_request(
           auth: $$azure_auth,
           verb: "patch",
@@ -519,14 +526,14 @@ define window_active($start_hour, $start_minute, $start_rule, $stop_hour, $stop_
   $next_stop    = $body['next_stop']
 end
 
-define handle_error($response) do 
+define handle_error($response) do
   $status_code = $response["code"]
   if $status_code == 404
     $_error_behavior = "skip"
-  else 
+  else
     $_error_behavior = "raise"
-  end 
-end 
+  end
+end
 
 define sys_log($subject, $detail) do
   rs_cm.audit_entries.create(


### PR DESCRIPTION
### Description

... for templates Azure Expiring RIs and (AWS) RI report by billing center.

(For the EU region, I can't use the built-in rightscale auth anymore; that's why it's replaced by a OAuth2 credentials (for now, until Phoenix implements a new built-in one).
All those changes are only done into a specific branch, EU_Policies (since this is kind of a temporary work-around, probably until ~Q4 when Phoenix gets their bit done), and not master.
 
The bit in my PR about the Azure scheduled instances is a merge from master into EU_Policies that I "piggy-backed" onto this PR.)

### Issues Resolved

https://jira.flexera.com/browse/CMLS-26
https://jira.flexera.com/browse/CMLS-27

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
