### PR TITLE
CMLS-31 CMLS-32 CMLS-34: RightScale auth to FlexeraOne OAuth2

### DIFF
--- a/cost/budget_v_actual/monthly_budget_v_actual.pt
+++ b/cost/budget_v_actual/monthly_budget_v_actual.pt
@@ -106,7 +106,12 @@ parameter "param_dec_monthly_budgeted" do
   description "Enter December budgeted cost."
 end
 
-auth "auth_rs", type: "rightscale"
+credentials "auth_rs" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select FlexeraOne OAuth2 credentials"
+  tags "provider=flexera"
+end
 
 datasource "ds_currency_reference" do
   request do

--- a/cost/instance_anomaly/instance_anomaly.pt
+++ b/cost/instance_anomaly/instance_anomaly.pt
@@ -45,13 +45,18 @@ end # parameter
 permission "perm_index_instances" do
   resources "rs_cm.instances"
   actions "rs_cm.index"
-end 
+end
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-auth "auth_rs", type: "rightscale"
+credentials "auth_rs" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select FlexeraOne OAuth2 credentials"
+  tags "provider=flexera"
+end
 
 ###############################################################################
 # Datasources

--- a/cost/instance_anomaly/instance_anomaly.pt
+++ b/cost/instance_anomaly/instance_anomaly.pt
@@ -45,18 +45,13 @@ end # parameter
 permission "perm_index_instances" do
   resources "rs_cm.instances"
   actions "rs_cm.index"
-end
+end 
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-credentials "auth_rs" do
-  schemes "oauth2"
-  label "flexera"
-  description "Select FlexeraOne OAuth2 credentials"
-  tags "provider=flexera"
-end
+auth "auth_rs", type: "rightscale"
 
 ###############################################################################
 # Datasources

--- a/cost/superseded_instance/superseded_instance.pt
+++ b/cost/superseded_instance/superseded_instance.pt
@@ -60,7 +60,12 @@ end
 # Authentication
 ###############################################################################
 
-auth "auth_rs", type: "rightscale"
+credentials "auth_rs" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select FlexeraOne OAuth2 credentials"
+  tags "provider=flexera"
+end
 
 ###############################################################################
 # Resources


### PR DESCRIPTION
### Description

Temporarily replace rightscale built-in auth with FlexeraOne OAuth2 credentials (until proper built-in F1 creds are available).
No updating the CHANGELOG: this is a specific branch (`EU_Policies`), temp workaround just for EU, avoid potential merge
conflicts with other changes in the main branch.

### Issues Resolved

https://jira.flexera.com/browse/CMLS-31
https://jira.flexera.com/browse/CMLS-32

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
