### PR TITLE
POL-442 Adding Budget Alert Threshold

### DIFF
--- a/cost/budget_alerts/CHANGELOG.md
+++ b/cost/budget_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.16
+
+- Adding budget threshold to policy.
+
 ## v1.15
 
 - Fixed markdown alignment in HERE doc, which was causing the conversion to HTML in the email to fail.

--- a/cost/budget_alerts/README.md
+++ b/cost/budget_alerts/README.md
@@ -17,6 +17,7 @@ This Policy uses Optima to determine if a Billing Center or the entire Organizat
 This policy has the following input parameters required when launching the policy.
 
 - *Monthly Budget* - specify the monthly budget.  Currency is irrelevant; the policy will default to whichever currency is used in Optima.
+- *Threshold Percentage* - Percentage of budget amount to alert on
 - *Billing Center Name or Id* - if the scope is "Billing Center", supply the name or Id of the target Billing Center. When left blank the policy reports on all the billing centers in the CMP Organization.
 - *Cost Metric* - specify options for amortized vs non-amortized and blended vs unblended costs
 - *Budget Alert Type* - Actual Spend alerts are based off incurred costs. Forecasted Spend alerts are based off monthly runrates

--- a/cost/budget_alerts/budget_alert.pt
+++ b/cost/budget_alerts/budget_alert.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "1.15",
+  version: "1.16",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -18,6 +18,13 @@ parameter "param_monthly_budget" do
   label "Monthly Budget"
   type "number"
   description "specify the monthly budget.  Currency is irrelevant; the policy will default to whichever currency is used in Optima"
+end
+
+parameter "param_threshold_percentage" do
+  label "Threshold Percentage"
+  type "number"
+  description "Percentage of budget amount to alert on"
+  default 100
 end
 
 parameter "param_bc_name" do
@@ -134,7 +141,7 @@ script "costs_request", type: "javascript" do
     mo = month.toString().length > 1 ? month : '0' + month;
     lmo = lmonth.toString().length > 1 ? lmonth : '0' + lmonth;
 
-    // wait for all the bill data to be collected, usually takes about 3 days	   
+    // wait for all the bill data to be collected, usually takes about 3 days
     var dt = new Date();
     if (dt.getDate() > 4){
       // start collecting bill data after its retrieved by Optima, roughly 3 days
@@ -263,7 +270,7 @@ script "js_filtered_billing_centers", type: "javascript" do
   result "filtered_billing_centers"
   code <<-EOS
   var filtered_billing_centers=[];
-    _.each(billing_centers, function(bc){ 
+    _.each(billing_centers, function(bc){
       if(param_bc_name==="Unallocated" && param_bc_name===bc.name){
         if(bc.parent_id==null){
           filtered_billing_centers.push(bc);
@@ -471,8 +478,8 @@ script "js_filter_target", type: "javascript" do
             id: bc["id"],
             budget: cur +formatNumber(param_monthly_budget,separator),
             total: bc["total"],
-			overBudgetAmount: overBudgetAmount,
-			overBudgetPercent: overBudgetPercent+"%",
+            overBudgetAmount: overBudgetAmount,
+            overBudgetPercent: overBudgetPercent+"%",
             forecastedSpend: forecastedSpend
           })
         }
@@ -535,7 +542,7 @@ end
 
 policy "budget_alert" do
   validate $filtered_target do
-    summary_template "{{ parameters.param_type }} Budget Exceeded"
+    summary_template "{{ parameters.param_type }} Budget Exceeded {{parameters.param_threshold_percentage}} Percent Threshold"
     # ignore changes to the monthly spend and runrate, since those will change constantly
     hash_exclude "actual", "runrate", "total"
     detail_template <<-EOS
@@ -546,7 +553,7 @@ policy "budget_alert" do
 ![Spending Overview Chart](https://image-charts.com/chart?{{ data.chartType }}&{{ data.chartData }}&{{ data.chartSize }}&{{ data.chartImage }}&{{ data.chartColor }}&{{ data.chartLebel }}&{{ data.chartYAxisLebel }}&{{ data.chartYAxis }}&{{ data.chartLebelPosition }}&{{data.chartDataAutoScale}}&{{data.chartDataValue}}&{{ data.chartTitle }}"Actual v. Monthly Cost Report")
 EOS
     escalate $esc_budget_alert
-    check lt(val(data,"total"),$param_monthly_budget)
+    check lt(val(data,"total"),prod($param_monthly_budget,div($param_threshold_percentage,100)))
     export "reportData" do
       resource_level true
       field "name" do


### PR DESCRIPTION
### Description

Adds a new parameter for budget threshold so customers can be alerted based on percentage of budget met. 

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
