### PR TITLE
POL-430 add check that AWS account array name exists before assigning it

### DIFF
--- a/cost/cheaper_regions/CHANGELOG.md
+++ b/cost/cheaper_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.11
+
+- Added check that AWS account array is not empty before assigning it
+
 ## v1.10
 
 - Modified escalation label and description for consistency

--- a/cost/cheaper_regions/cheaper_regions.pt
+++ b/cost/cheaper_regions/cheaper_regions.pt
@@ -1,4 +1,4 @@
-name "Cheaper Regions - test"
+name "Cheaper Regions"
 rs_pt_ver 20180301
 type "policy"
 short_description "Specify which regions have cheaper alternatives by specifying the expensive region name and the cheaper region name for analysis. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/cheaper_regions/) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."

--- a/cost/cheaper_regions/cheaper_regions.pt
+++ b/cost/cheaper_regions/cheaper_regions.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "1.10",
+  version: "1.11",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -268,7 +268,12 @@ script "js_merge_bc_name", type: "javascript" do
       if ( vendor == "AWS" ){
         var new_region = ec2_cheaper_regions["regions"][new_bc_costs[i].region]
         var account = _.reject(ds_cloud_vendor_accounts, function(ds_cloud_vendor_account){ return ds_cloud_vendor_account.id != new_bc_costs[i].vendor_account_name });
-        var vendor_account_name = account[0].name
+        if(account || account.length){
+          var vendor_account_name = account[0].name
+        }else{
+          console.log("aws account name is empty")
+          var vendor_account_name = ""
+        }
       } else if ( vendor == "AzureCSP" || vendor == "Azure" ) {
         var new_region = azure_cheaper_regions["regions"][new_bc_costs[i].region]
         var vendor_account_name = new_bc_costs[i].vendor_account_name
@@ -333,7 +338,7 @@ policy "policy_cheaper_regions" do
       field "id" do
         label "Resource ID"
       end
-    end 
+    end
   end
 end
 

--- a/cost/cheaper_regions/cheaper_regions.pt
+++ b/cost/cheaper_regions/cheaper_regions.pt
@@ -1,4 +1,4 @@
-name "Cheaper Regions"
+name "Cheaper Regions - test"
 rs_pt_ver 20180301
 type "policy"
 short_description "Specify which regions have cheaper alternatives by specifying the expensive region name and the cheaper region name for analysis. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/cheaper_regions/) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
@@ -268,9 +268,9 @@ script "js_merge_bc_name", type: "javascript" do
       if ( vendor == "AWS" ){
         var new_region = ec2_cheaper_regions["regions"][new_bc_costs[i].region]
         var account = _.reject(ds_cloud_vendor_accounts, function(ds_cloud_vendor_account){ return ds_cloud_vendor_account.id != new_bc_costs[i].vendor_account_name });
-        if(account || account.length){
+        if(account && account.length){
           var vendor_account_name = account[0].name
-        }else{
+        } else {
           console.log("aws account name is empty")
           var vendor_account_name = ""
         }

--- a/cost/cheaper_regions/cheaper_regions.pt
+++ b/cost/cheaper_regions/cheaper_regions.pt
@@ -268,7 +268,7 @@ script "js_merge_bc_name", type: "javascript" do
       if ( vendor == "AWS" ){
         var new_region = ec2_cheaper_regions["regions"][new_bc_costs[i].region]
         var account = _.reject(ds_cloud_vendor_accounts, function(ds_cloud_vendor_account){ return ds_cloud_vendor_account.id != new_bc_costs[i].vendor_account_name });
-        if(account && account.length){
+        if ( account && account.length ){
           var vendor_account_name = account[0].name
         } else {
           console.log("aws account name is empty")


### PR DESCRIPTION
### Description

Added check that AWS account array is not empty before assigning it

### Issues Resolved

Bug with error "Cannot access member 'name' of undefined" from trying to access an empty array

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
