### PR TITLE
July 7th 2021 - Add Missing RDS Instance Sizes

### DIFF
--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -443,6 +443,14 @@
   "db.m6g.12xlarge": {"vcpu": "48", "up": "db.m6g.16xlarge", "down": "db.m6g.8xlarge"},
   "db.m6g.16xlarge": {"vcpu": "64", "up": null, "down": "db.m6g.12xlarge"},
 
+  "db.r6g.large": {"vcpu": "2", "up": "db.r6g.xlarge", "down": null},
+  "db.r6g.xlarge": {"vcpu": "4", "up": "db.r6g.2xlarge", "down": "db.r6g.large"},
+  "db.r6g.2xlarge": {"vcpu": "8", "up": "db.r6g.4xlarge", "down": "db.r6g.xlarge"},
+  "db.r6g.4xlarge": {"vcpu": "16", "up": "db.r6g.8xlarge", "down": "db.r6g.2xlarge"},
+  "db.r6g.8xlarge": {"vcpu": "32", "up": "db.r6g.16xlarge", "down": "db.r6g.4xlarge"},
+  "db.r6g.12xlarge": {"vcpu": "48", "up": "db.r6g.16xlarge", "down": "db.r6g.8xlarge"},
+  "db.r6g.16xlarge": {"vcpu": "64", "up": null, "down": "db.r6g.12xlarge"},
+
   "db.r4.large": {"vcpu": "2", "up": "db.r4.xlarge", "down": null},
   "db.r4.xlarge": {"vcpu": "4", "up": "db.r4.2xlarge", "down": "db.r4.large"},
   "db.r4.2xlarge": {"vcpu": "8", "up": "db.r4.4xlarge", "down": "db.r4.xlarge"},

--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -43,7 +43,7 @@
   "c5d.18xlarge": {"up": "c5d.24xlarge", "down": "c5d.12xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "c5d.24xlarge": {"up": null, "down": "c5d.18xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "c5d.metal": {"up": null, "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
-  
+
   "c5ad.large": {"up": "c5ad.xlarge", "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "c5ad.xlarge": {"up": "c5ad.2xlarge", "down": "c5ad.large", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "c5ad.2xlarge": {"up": "c5ad.4xlarge", "down": "c5ad.xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
@@ -52,7 +52,7 @@
   "c5ad.12xlarge": {"up": "c5ad.16xlarge", "down": "c5ad.8xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "c5ad.16xlarge": {"up": "c5ad.24xlarge", "down": "c5ad.12xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "c5ad.24xlarge": {"up": null, "down": "c5ad.16xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
-    
+
   "c5n.large": {"up": "c5n.xlarge", "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "c5n.xlarge": {"up": "c5n.2xlarge", "down": "c5n.large", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "c5n.2xlarge": {"up": "c5n.4xlarge", "down": "c5n.xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
@@ -82,7 +82,7 @@
   "cc2.8xlarge": {"up": null, "down": null, "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "cg1.4xlarge": {"up": null, "down": null, "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "cr1.8xlarge": {"up": null, "down": null, "superseded": {"regular": "r3.8xlarge","next_gen": "r4.8xlarge", "burstable": "", "amd": ""}, "ec2_classic": true, "enhanced_networking": false},
-  
+
   "d2.xlarge": {"up": "d2.2xlarge", "down": null, "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "d2.2xlarge": {"up": "d2.4xlarge", "down": "d2.xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "d2.4xlarge": {"up": "d2.8xlarge", "down": "d2.2xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
@@ -92,14 +92,14 @@
   "d3.2xlarge": {"up": "d3.4xlarge", "down": "d3.xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "d3.4xlarge": {"up": "d3.8xlarge", "down": "d3.2xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "d3.8xlarge": {"up": null, "down": "d3.4xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
-  
+
   "d3en.xlarge": {"up": "d3en.2xlarge", "down": null, "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "d3en.2xlarge": {"up": "d3en.4xlarge", "down": "d3en.xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "d3en.4xlarge": {"up": "d3en.6xlarge", "down": "d3en.2xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "d3en.6xlarge": {"up": "d3en.8xlarge", "down": "d3en.4xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "d3en.8xlarge": {"up": "d3en.12xlarge", "down": "d3en.6xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
   "d3en.12xlarge": {"up": null, "down": "d3en.8xlarge", "superseded": null, "ec2_classic": true, "enhanced_networking": false},
-   
+
   "p2.xlarge": {"up": "p2.8xlarge", "down": null, "superseded": {"regular": "p3.xlarge","next_gen": null, "burstable": "", "amd": ""}, "ec2_classic": false, "enhanced_networking": true},
   "p2.8xlarge": {"up": "p2.16xlarge", "down": "p2.xlarge", "superseded": {"regular": "p3.8xlarge","next_gen": null, "burstable": "", "amd": ""}, "ec2_classic": false, "enhanced_networking": true},
   "p2.16xlarge": {"up": null, "down": "p2.8xlarge", "superseded": {"regular": "p3.16xlarge","next_gen": null, "burstable": "", "amd": ""}, "ec2_classic": false, "enhanced_networking": true},
@@ -124,7 +124,7 @@
   "g4.16xlarge": {"up": null, "down": "g4.8xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "g4dn.12xlarge": {"up": null, "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "g4dn.metal": {"up": null, "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
-  
+
   "g4ad.4xlarge": {"up": "g4ad.8xlarge", "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "g4ad.8xlarge": {"up": "g4ad.16xlarge", "down": "g4ad.4xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "g4ad.16xlarge": {"up": null, "down": "g4ad.8xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
@@ -134,7 +134,7 @@
   "g4dn.4xlarge": {"up": "g4dn.8xlarge", "down": "g4dn.2xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "g4dn.8xlarge": {"up": "g4dn.16xlarge", "down": "g4dn.4xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "g4dn.16xlarge": {"up": null, "down": "g4dn.8xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
-  
+
   "f1.2xlarge": {"up": "f1.4xlarge", "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "f1.4xlarge": {"up": "f1.16xlarge", "down": "f1.2xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "f1.16xlarge": {"up": null, "down": "f1.4xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
@@ -207,7 +207,7 @@
   "m5dn.16xlarge": {"up": "m5dn.24xlarge", "down": "m5dn.12xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "m5dn.24xlarge": {"up": null, "down": "m5dn.16xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "m5dn.metal": {"up": null, "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
-  
+
   "m5zn.large": {"up": "m5zn.xlarge", "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "m5zn.xlarge": {"up": "m5zn.2xlarge", "down": "m5zn.large", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "m5zn.2xlarge": {"up": "m5zn.3xlarge", "down": "m5zn.xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
@@ -217,7 +217,7 @@
   "m5zn.metal": {"up": null, "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
 
   "mac1.metal": {"up": null, "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
-  
+
   "p4d.24xlarge": {"up": null, "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
 
   "m6g.medium": {"up": "m6g.large", "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
@@ -293,7 +293,7 @@
   "r5a.12xlarge": {"up": "r5a.16xlarge", "down": "r5a.8xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "r5a.16xlarge": {"up": "r5a.24xlarge", "down": "r5a.12xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "r5a.24xlarge": {"up": null, "down": "r5a.16xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
-  
+
   "r5b.large": {"up": "r5b.xlarge", "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "r5b.xlarge": {"up": "r5b.2xlarge", "down": "r5b.large", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
   "r5b.2xlarge": {"up": "r5b.4xlarge", "down": "r5b.xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true},
@@ -399,7 +399,7 @@
   "t3a.large": {"up": "t3.xlarge", "down": "t3.medium", "superseded": null, "ec2_classic": false, "enhanced_networking": true, "burst_info": { "credits_per_hour": 36, "max_earnable_credits": 864}},
   "t3a.xlarge": {"up": "t3.2xlarge", "down": "t3.large", "superseded": null, "ec2_classic": false, "enhanced_networking": true, "burst_info": { "credits_per_hour": 96, "max_earnable_credits": 2304}},
   "t3a.2xlarge": {"up": null, "down": "t3.xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true, "burst_info": { "credits_per_hour": 192, "max_earnable_credits": 4608}},
-  
+
   "t4g.nano": {"up": "t4g.micro", "down": null, "superseded": null, "ec2_classic": false, "enhanced_networking": true, "burst_info": { "credits_per_hour": 6, "max_earnable_credits": 144}},
   "t4g.micro": {"up": "t4g.small", "down": "t4g.nano", "superseded": null, "ec2_classic": false, "enhanced_networking": true, "burst_info": { "credits_per_hour": 12, "max_earnable_credits": 288}},
   "t4g.small": {"up": "t4g.medium", "down": "t4g.micro", "superseded": null, "ec2_classic": false, "enhanced_networking": true, "burst_info": { "credits_per_hour": 24, "max_earnable_credits": 576}},
@@ -408,6 +408,7 @@
   "t4g.xlarge": {"up": "t4g.2xlarge", "down": "t4g.large", "superseded": null, "ec2_classic": false, "enhanced_networking": true, "burst_info": { "credits_per_hour": 96, "max_earnable_credits": 2304}},
   "t4g.2xlarge": {"up": null, "down": "t4g.xlarge", "superseded": null, "ec2_classic": false, "enhanced_networking": true, "burst_info": { "credits_per_hour": 192, "max_earnable_credits": 4608}},
 
+  "db.t1.micro": {"vcpu": "1", "up": null, "down": null},
   "db.t2.micro": {"vcpu": "1", "up": "db.t2.small", "down": null},
   "db.t2.small": {"vcpu": "1", "up": "db.t2.medium", "down": "db.t2.micro"},
   "db.t2.medium": {"vcpu": "2", "up": "db.t2.large", "down": "db.t2.small"},
@@ -433,6 +434,15 @@
   "db.m5.12xlarge": {"vcpu": "48", "up": "db.m5.16xlarge", "down": "db.m5.4xlarge"},
   "db.m5.16xlarge": {"vcpu": "64", "up": "db.m5.24xlarge", "down": "db.m5.12xlarge"},
   "db.m5.24xlarge": {"vcpu": "96", "up": null, "down": "db.m5.12xlarge"},
+
+  "db.m6g.large": {"vcpu": "2", "up": "db.m6g.xlarge", "down": null},
+  "db.m6g.xlarge": {"vcpu": "4", "up": "db.m6g.2xlarge", "down": "db.m6g.large"},
+  "db.m6g.2xlarge": {"vcpu": "8", "up": "db.m6g.4xlarge", "down": "db.m6g.xlarge"},
+  "db.m6g.4xlarge": {"vcpu": "16", "up": "db.m6g.8xlarge", "down": "db.m6g.2xlarge"},
+  "db.m6g.8xlarge": {"vcpu": "32", "up": "db.m6g.16xlarge", "down": "db.m6g.4xlarge"},
+  "db.m6g.12xlarge": {"vcpu": "48", "up": "db.m6g.16xlarge", "down": "db.m6g.8xlarge"},
+  "db.m6g.16xlarge": {"vcpu": "64", "up": null, "down": "db.m6g.12xlarge"},
+
   "db.r4.large": {"vcpu": "2", "up": "db.r4.xlarge", "down": null},
   "db.r4.xlarge": {"vcpu": "4", "up": "db.r4.2xlarge", "down": "db.r4.large"},
   "db.r4.2xlarge": {"vcpu": "8", "up": "db.r4.4xlarge", "down": "db.r4.xlarge"},


### PR DESCRIPTION
### Description

Updates the instance size mapping table to support db.m6g.*, db.r6g.*,  and db.t1.micro

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
