### PR TITLE
POL-445: RDS Rightsizing Policy: Update next instance size logic to account for missing size

### DIFF
--- a/cost/aws/rds_instance_cloudwatch_utilization/CHANGELOG.md
+++ b/cost/aws/rds_instance_cloudwatch_utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Updated next instance size logic to account for missing instance type in instance_types.json
+
 ## v2.8
 
 - Debug log via param (off by default)

--- a/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
+++ b/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
@@ -261,8 +261,13 @@ script "js_instances", type: "javascript" do
         continue
       } else {
         var instance_type = instance.dbInstanceClass
-        var size_up = ds_aws_instance_size_map[instance_type.toString()]["up"]
-        var size_down = ds_aws_instance_size_map[instance_type.toString()]["down"]
+        if(ds_aws_instance_size_map[instance_type.toString()] !== undefined && ds_aws_instance_size_map[instance_type.toString()] != null){
+          var size_up = ds_aws_instance_size_map[instance_type.toString()]["up"]
+          var size_down = ds_aws_instance_size_map[instance_type.toString()]["down"]
+        } else {
+          var size_up = "N/A"
+          var size_down = "N/A"
+        }
         results.push ({
           "region": instance.region,
           "availabilityZone": instance.availabilityZone,

--- a/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
+++ b/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "RDS",
   policy_set: "RightSize Database Services"


### PR DESCRIPTION
### Description

This update fixes the logic in the policy that calculates the next instance size to reflect "N/A" as opposed to failing if the next instance size is not captured in the instance_types.json mapping file.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
