### PR TITLE
POL-449: Convert resource type to lowercase for comparisons

### DIFF
--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7
+
+- Convert resource type to lower case for comparison (Microsoft is not consistent with the case)
+
 ## v2.6
 
 - Drop namespace from resource type when looking up supported API versions

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -4,6 +4,7 @@ type "policy"
 short_description "Find all Azure resources missing any of the user provided tags with the option to update the resources with the missing tags. See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/azure/azure_untagged_resources) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
 category "Compliance"
 severity "low"
+default_frequency "daily"
 info(
    version: "2.7",
    provider: "Azure",

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -5,7 +5,7 @@ short_description "Find all Azure resources missing any of the user provided tag
 category "Compliance"
 severity "low"
 info(
-   version: "2.6",
+   version: "2.7",
    provider: "Azure",
    service: "",
    policy_set: "Untagged Resources"
@@ -136,7 +136,7 @@ script "js_parse_tag_support", type: "javascript" do
     rows.shift();
     _.each(rows, function(row){
       var fields = row.split(',');
-      result[fields[0]+"/"+fields[1]] = fields[2];
+      result[(fields[0]+"/"+fields[1]).toLowerCase()] = fields[2];
     });
 EOS
 end
@@ -163,7 +163,7 @@ script "js_filter_resources", type: "javascript" do
       var all_include_tag='';
       var all_missed_tag='';
       var all_tags={};
-      var tag_support=ds_parsed_tag_support[ar["type"]];
+      var tag_support=ds_parsed_tag_support[ar["type"].toLowerCase()];
       if(!(_.isEmpty(resource_tags))){
       all_tags=ar.tags;
       }


### PR DESCRIPTION
### Description

Microsoft is not consistent with the case of its resource types; work around this by converting to lower case when|
comparing types from various sources across Microsoft.

### Issues Resolved

https://jira.flexera.com/browse/POL-449

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
