### PR TITLE
Pol 474 ensure admin iam policies not attached

### DIFF
--- a/security/aws/iam_no_admin_iam_policies_attached/CHANGELOG.md
+++ b/security/aws/iam_no_admin_iam_policies_attached/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v2.0
+
+- initial release

--- a/security/aws/iam_no_admin_iam_policies_attached/README.md
+++ b/security/aws/iam_no_admin_iam_policies_attached/README.md
@@ -1,0 +1,53 @@
+# AWS Report Attached Admin IAM Policies
+
+## What it does
+
+Generally speaking, AWS policies should grant specific permissions based on the principle of least privilege. This policy checks for any attached AWS policies that have full administrative rights and raises an incident if any are present.
+
+## Functional Details
+
+When attached AWS policies that have full administrative rights are found, this policy raises an incident and provides a list of relevant policies.
+
+## Input Parameters
+
+- *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
+
+## Policy Actions
+
+- Send an email report
+
+## Prerequisites
+
+This policy uses [credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+
+### Credential configuration
+
+For administrators [creating and managing credentials](https://docs.rightscale.com/policies/users/guides/credential_management.html) to use with this policy, the following information is needed:
+
+Provider tag value to match this policy: `aws` , `aws_sts`
+
+Required permissions in the provider:
+
+```javascript
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sts:GetCallerIdentity",
+                "iam:GetAccountSummary"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+## Supported Clouds
+
+- AWS
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/security/aws/iam_no_admin_iam_policies_attached/README.md
+++ b/security/aws/iam_no_admin_iam_policies_attached/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-Generally speaking, AWS policies should grant specific permissions based on the principle of least privilege. This policy checks for any attached AWS policies that have full administrative rights and raises an incident if any are present.
+AWS policies should grant specific permissions based on the principle of least privilege. This policy checks for any attached AWS policies that have full unrestricted administrative rights and raises an incident if any are present.
 
 ## Functional Details
 
@@ -35,8 +35,9 @@ Required permissions in the provider:
         {
             "Effect": "Allow",
             "Action": [
-                "sts:GetCallerIdentity",
-                "iam:GetAccountSummary"
+                "iam:ListPolicies",
+                "iam:GetPolicyVersion",
+                "sts:GetCallerIdentity"
             ],
             "Resource": "*"
         }

--- a/security/aws/iam_no_admin_iam_policies_attached/iam_no_admin_iam_policies_attached.pt
+++ b/security/aws/iam_no_admin_iam_policies_attached/iam_no_admin_iam_policies_attached.pt
@@ -44,6 +44,25 @@ end
 # Datasources
 ###############################################################################
 
+# Retrieve the id number of the account being tested
+datasource "ds_get_caller_identity" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "sts.amazonaws.com"
+    path "/"
+    header "User-Agent", "RS Policies"
+    query "Action", "GetCallerIdentity"
+    query "Version", "2011-06-15"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
+      field "account",xpath(col_item, "Account")
+    end
+  end
+end
+
 # Retrieve a boolean variable that indicates if any account keys have root access
 datasource "ds_iam_listpolicies" do
   request do
@@ -59,44 +78,119 @@ datasource "ds_iam_listpolicies" do
   end
   result do
     encoding "json"
-    collect jmes_path(response, "GetListPoliciesResponse.GetListPoliciesResult.Policies[*]") do
+    collect jmes_path(response, "ListPoliciesResponse.ListPoliciesResult.Policies[*]") do
       field "policyName", jmes_path(col_item, "PolicyName")
       field "arn", jmes_path(col_item, "Arn")
+      field "versionId", jmes_path(col_item, "DefaultVersionId")
     end
   end
 end
 
-# datasource "ds_iam_policyversions" do
-#   iterate $ds_iam_listpolicies
-#   request do
-#     auth $auth_aws
-#     verb "GET"
-#     host "iam.amazonaws.com"
-#     path "/"
-#     query "Action", "GetPolicyVersion"
-#     query "PolicyArn", val(iter_item, "Arn")
-#     query "VersionId", "v1"
-#     query "Version", "2010-05-08"
-#     query "OnlyAttached", "true"
-#     header "Accept", "application/json"
-#     header "User-Agent", "RS Policies"
-#   end
-#   result do
-#     encoding "json"
-#     collect jmes_path(response, "GetPolicyVersionResponse.GetPolicyVersionResult.PolicyVersion.Document.Statement[*]") do
-#       field "policyName", jmes_path(iter_item, "policyName")
-#       field "arn", jmes_path(iter_item, "arn")
-#       field "action", jmes_path(col_item, "Action")
-#       field "effect", jmes_path(col_item, "Effect")
-#       field "resource", jmes_path(col_item, "Resource")
-#     end
-#   end
-# end
+# Notes from AWS documentation:
+# Policies returned by this operation are URL-encoded compliant with RFC 3986.
+# You can use a URL decoding method to convert the policy back to plain JSON text.
+# For example, if you use Java, you can use the decode method of the java.net.URLDecoder
+# utility class in the Java SDK. Other languages and SDKs provide similar functionality.
+datasource "ds_iam_policyversions" do
+  iterate $ds_iam_listpolicies
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "iam.amazonaws.com"
+    path "/"
+    query "Action", "GetPolicyVersion"
+    query "PolicyArn", val(iter_item, "arn")
+    query "VersionId", val(iter_item, "versionId")
+    query "Version", "2010-05-08"
+    query "OnlyAttached", "true"
+    header "Accept", "application/json"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    field "policyName", jmes_path(iter_item, "policyName")
+    field "arn", jmes_path(iter_item, "arn")
+    field "versionId", jmes_path(iter_item, "versionId")
+    field "encoded_details", jmes_path(response, "GetPolicyVersionResponse.GetPolicyVersionResult.PolicyVersion.Document")
+  end
+end
+
+# Combine ds_get_caller_identity and ds_iam_accesskeys into a single datasource
+datasource "ds_iam_policies" do
+  run_script $js_iam_policies, $ds_iam_policyversions, $ds_get_caller_identity
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+# Script to combine ds_get_caller_identity and ds_iam_accesskeys into a single datasource
+script "js_iam_policies", type:"javascript" do
+  parameters "ds_iam_policyversions", "ds_get_caller_identity"
+  result "result"
+  code <<-EOS
+    var bad_policy_list = [];
+
+    _.each(ds_iam_policyversions, function(policy){
+      statement_list = JSON.parse(decodeURIComponent(policy.encoded_details))['Statement']
+      bad_policy = 0
+
+      _.each(statement_list, function(statement){
+        if (statement['Effect'] == 'Allow' && statement['Action'] == '*' && statement['Resource'] == '*') {
+          bad_policy = 1
+        }
+      })
+
+      if (bad_policy == 1) {
+        bad_policy_list.push(policy['policyName'] + ": " + policy['arn'])
+      }
+
+    })
+
+    result = {
+      id: ds_get_caller_identity[0]['account'],
+      bad_policy_list: bad_policy_list
+    }
+EOS
+end
 
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_no_admin_iam_policies" do
+  validate $ds_iam_policies do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): Users Without MFA Found"
+    escalate $esc_no_admin_iam_policies
+    detail_template <<-EOS
+Attached policies with full admin access found.
 
+Affected Account: {{data.id}}
+Problematic Policies:
+{{- range $val := data.bad_policy_list }}
+  {{ $val }}
+{{- end }}
+EOS
+    check eq(size(val(data, "bad_policy_list")),0)
+    export do
+      resource_level true
+      field "id" do
+        label "id"
+      end
+      field "bad_policy_list" do
+        label "bad_policy_list"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_no_admin_iam_policies" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
 end

--- a/security/aws/iam_no_admin_iam_policies_attached/iam_no_admin_iam_policies_attached.pt
+++ b/security/aws/iam_no_admin_iam_policies_attached/iam_no_admin_iam_policies_attached.pt
@@ -1,0 +1,102 @@
+name "AWS IAM Report Attached Admin IAM Policies"
+rs_pt_ver 20180301
+type "policy"
+short_description "Report any admin IAM policies that are attached. \n See the [README](https://github.com/flexera/policy_templates/tree/master/security/aws/iam_no_admin_iam_policies_attached) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+long_description ""
+category "Security"
+severity "high"
+default_frequency "daily"
+info(
+  version: "2.0",
+  provider: "AWS",
+  service: "IAM",
+  policy_set: "CIS",
+  cce_id: "CCE-78912-3",
+  cis_aws_foundations_securityhub: "1.22",
+  benchmark_control: "1.16",
+  benchmark_version: "1.4.0",
+  cis_controls: "[\"3.3v8\", \"4v7\"]",
+  nist: "AC-6"
+)
+
+###############################################################################
+# User inputs
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  label "Email Address"
+  description "Email addresses of the recipients you wish to notify"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_aws" do
+  schemes "aws","aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list"
+  tags "provider=aws"
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+# Retrieve a boolean variable that indicates if any account keys have root access
+datasource "ds_iam_listpolicies" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "iam.amazonaws.com"
+    path "/"
+    query "Action", "ListPolicies"
+    query "Version", "2010-05-08"
+    query "OnlyAttached", "true"
+    header "Accept", "application/json"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "GetListPoliciesResponse.GetListPoliciesResult.Policies[*]") do
+      field "policyName", jmes_path(col_item, "PolicyName")
+      field "arn", jmes_path(col_item, "Arn")
+    end
+  end
+end
+
+# datasource "ds_iam_policyversions" do
+#   iterate $ds_iam_listpolicies
+#   request do
+#     auth $auth_aws
+#     verb "GET"
+#     host "iam.amazonaws.com"
+#     path "/"
+#     query "Action", "GetPolicyVersion"
+#     query "PolicyArn", val(iter_item, "Arn")
+#     query "VersionId", "v1"
+#     query "Version", "2010-05-08"
+#     query "OnlyAttached", "true"
+#     header "Accept", "application/json"
+#     header "User-Agent", "RS Policies"
+#   end
+#   result do
+#     encoding "json"
+#     collect jmes_path(response, "GetPolicyVersionResponse.GetPolicyVersionResult.PolicyVersion.Document.Statement[*]") do
+#       field "policyName", jmes_path(iter_item, "policyName")
+#       field "arn", jmes_path(iter_item, "arn")
+#       field "action", jmes_path(col_item, "Action")
+#       field "effect", jmes_path(col_item, "Effect")
+#       field "resource", jmes_path(col_item, "Resource")
+#     end
+#   end
+# end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_no_admin_iam_policies" do
+
+end

--- a/security/aws/iam_no_admin_iam_policies_attached/iam_no_admin_iam_policies_attached.pt
+++ b/security/aws/iam_no_admin_iam_policies_attached/iam_no_admin_iam_policies_attached.pt
@@ -166,9 +166,10 @@ policy "pol_no_admin_iam_policies" do
 Attached policies with full admin access found.
 
 Affected Account: {{data.id}}
+
 Problematic Policies:
 {{- range $val := data.bad_policy_list }}
-  {{ $val }}
+  {{ $val }}\n
 {{- end }}
 EOS
     check eq(size(val(data, "bad_policy_list")),0)


### PR DESCRIPTION
### Description

Adds policy for AWS IAM 1.16 Ensure IAM policies that allow full "*:*" administrative privileges are not attached
