### PR TITLE
updated to include CIS info

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,11 @@ Reference
 
 ##### Database
 
-- [AWS Unencrypted RDS Instances](./security/aws/rds_unencrypted/)
 - [AWS Publicly Accessible RDS Instances](./security/aws/rds_publicly_accessible/)
+
+###### CIS Policies
+
+- [AWS Unencrypted RDS Instances](./security/aws/rds_unencrypted/)
 
 ##### Storage
 

--- a/security/aws/rds_unencrypted/CHANGELOG.md
+++ b/security/aws/rds_unencrypted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6
+
+- Added CIS standards information to metadata
+
 ## v2.5
 
 - Added a new input parameter to enter regions in order to support SCP (Service Control Policy) and CIS Standards

--- a/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
+++ b/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
@@ -6,10 +6,16 @@ long_description ""
 category "Security"
 severity "medium"
 info(
-  version: "2.5",
+  version: "2.6",
   provider: "AWS",
   service: "RDS",
-  policy_set: ""
+  policy_set: "CIS",
+  cce_id: "", # Not applicable
+  cis_aws_foundations_securityhub: "", # Not applicable
+  benchmark_control: "2.3.1",
+  benchmark_version: "1.4.0",
+  cis_controls: "[\"14.8v7\", \"3.11v8\"]",
+  nist: "" # Not applicable
 )
 
 ###############################################################################
@@ -327,7 +333,7 @@ end
 escalation "report_unencrypted_RDS_instances" do
   automatic true
   label "Send Email"
-  description "Send incident email" 
+  description "Send incident email"
   email $param_email
 end
 
@@ -396,7 +402,7 @@ define delete_unencrypted_RDS_instances($data) return $all_responses do
             query_strings: {
               "Action": "DeleteDBInstance",
               "Version": "2014-10-31",
-              "DeleteAutomatedBackups": $item["id"]			
+              "DeleteAutomatedBackups": $item["id"]
             }
           )
 		end


### PR DESCRIPTION
### Description

Policy already exists that enforces AWS CIS 2.3.1 Ensure that encryption is enabled for RDS Instances. This just updates the global README and policy metadata to include that.