### PR TITLE
added CIS metadata and updated global README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,10 @@ Reference
 ##### Storage
 
 - [AWS Open Buckets](./security/storage/aws/public_buckets/)
-- [AWS Unencrypted S3 Buckets](./security/aws/unencrypted_s3_buckets/)
 - [AWS Unencrypted Volumes](./security/aws/ebs_unencrypted_volumes/)
+
+###### CIS Policies
+- [AWS Unencrypted S3 Buckets](./security/aws/unencrypted_s3_buckets/)
 
 ##### Load Balancers
 

--- a/security/aws/unencrypted_s3_buckets/CHANGELOG.md
+++ b/security/aws/unencrypted_s3_buckets/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4
+
+- Added CIS metadata to policy
+
 ## v2.3
 
 - Modified escalation label and description for consistency

--- a/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets.pt
+++ b/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets.pt
@@ -6,10 +6,16 @@ long_description ""
 category "Security"
 severity "low"
 info(
-  version: "2.3",
+  version: "2.4",
   provider: "AWS",
   service: "S3",
-  policy_set: ""
+  policy_set: "CIS",
+  cce_id: "", # not applicable
+  cis_aws_foundations_securityhub: "", # not applicable
+  benchmark_control: "2.1.1",
+  benchmark_version: "1.4.0",
+  cis_controls: "[\"3.11v8\", \"14.8v7\"]",
+  nist: "" # not applicable
 )
 
 ###############################################################################


### PR DESCRIPTION
### Description

A policy already existed that works for AWS CIS 2.1.1 Ensure all S3 buckets employ encryption-at-rest.
This updates the policy's metadata and the global README to reflect this.