### PR TITLE
Pol 508 add cost to google recommender

### DIFF
--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- Added cost to incident output
+
 ## v2.1
 
 - Updating the short description

--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.2
 
-- Added cost to incident output
+- Added cost to incident output and ability to filter by projects
 
 ## v2.1
 

--- a/cost/google/recommender/README.md
+++ b/cost/google/recommender/README.md
@@ -11,6 +11,7 @@ This policy has the following input parameters required when launching the polic
 - *Email addresses* - A list of email addresses to notify
 - *Recommender to Check* - [Google recommender](https://cloud.google.com/recommender/docs/recommenders) to run the policy against
 - *Location* - Location to check, it can be the zone, region or global
+- *Project ID* - Google Projects to Query. Leave blank to query all projects.
 
 ## Policy Actions
 

--- a/cost/google/recommender/recommender.pt
+++ b/cost/google/recommender/recommender.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.1",
+  version: "2.2",
   provider:"Google",
   service: "Storage",
   policy_set: "Native Recommendations"
@@ -116,6 +116,7 @@ datasource "ds_recommendations" do
       field "resourceName", jmes_path(col_item, "content.overview.resourceName")
       field "description", jmes_path(col_item, "description")
       field "primaryImpact", jmes_path(col_item, "primaryImpact")
+      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
       field "priority", jmes_path(col_item, "priority")
       field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
       field "state", jmes_path(col_item, "stateInfo.state")
@@ -204,6 +205,9 @@ policy "policy_recommendations" do
       field "primary_impact" do
         label "Primary Impact"
         path "primaryImpact.category"
+      end
+      field "costUnits" do
+        label "Cost"
       end
       field "priority" do
         label "Priority"

--- a/cost/google/recommender/recommender.pt
+++ b/cost/google/recommender/recommender.pt
@@ -47,6 +47,14 @@ parameter "param_location_whitelist" do
   type "list"
   label "Location"
   description "Location to check, it can be the zone, region or global"
+  default ["global"]
+end
+
+parameter "param_project" do
+  type "list"
+  label "Project ID"
+  description "Google Projects to Query. Leave blank to query all projects."
+  default []
 end
 
 ###############################################################################
@@ -97,7 +105,7 @@ end
 
 
 datasource "ds_recommenders" do
-  run_script $js_recommenders, $param_location_whitelist, $param_recommenders, $ds_google_project
+  run_script $js_recommenders, $param_location_whitelist, $param_recommenders, $ds_google_project, $param_project
 end
 
 datasource "ds_recommendations" do
@@ -117,6 +125,7 @@ datasource "ds_recommendations" do
       field "description", jmes_path(col_item, "description")
       field "primaryImpact", jmes_path(col_item, "primaryImpact")
       field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
+      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
       field "priority", jmes_path(col_item, "priority")
       field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
       field "state", jmes_path(col_item, "stateInfo.state")
@@ -128,7 +137,7 @@ end
 # Scripts
 ###############################################################################
 script "js_recommenders", type: "javascript" do
-  parameters "param_location_whitelist", "param_recommenders", "ds_google_project"
+  parameters "param_location_whitelist", "param_recommenders", "ds_google_project", "param_project"
   result "results"
   code <<-EOF
   var results = []
@@ -148,16 +157,19 @@ script "js_recommenders", type: "javascript" do
     "VM machine type recommender": "google.compute.instance.MachineTypeRecommender",
     "Unattended project recommender": "google.resourcemanager.projectUtilization.Recommender",
   }
+
   recommenders = recommender_map[param_recommenders]
   _.each(ds_google_project, function(project){
-    _.each(param_location_whitelist, function(location){
-      results.push({
-        projectNumber: project.projectNumber,
-        projectId: project.projectId,
-        location: location,
-        recommender: recommenders
+    if (_.contains(param_project, project.projectId) || param_project.length == 0) {
+      _.each(param_location_whitelist, function(location){
+        results.push({
+          projectNumber: project.projectNumber,
+          projectId: project.projectId,
+          location: location,
+          recommender: recommenders
+        })
       })
-    })
+    }
   })
 EOF
 end
@@ -173,6 +185,7 @@ script "js_recommender_call", type: "javascript" do
     auth: "auth_google",
     pagination: "google_pagination",
     host: "recommender.googleapis.com",
+    ignore_status: 403,
     path: "/v1/projects/"+ projectId +"/locations/" + location + "/recommenders/" + recommender + "/recommendations",
     query_strings: { alt: "json" }
   }
@@ -208,6 +221,9 @@ policy "policy_recommendations" do
       end
       field "costUnits" do
         label "Cost"
+      end
+      field "currency" do
+        label "Currency"
       end
       field "priority" do
         label "Priority"

--- a/cost/google/recommender/recommender.pt
+++ b/cost/google/recommender/recommender.pt
@@ -47,7 +47,6 @@ parameter "param_location_whitelist" do
   type "list"
   label "Location"
   description "Location to check, it can be the zone, region or global"
-  default ["global"]
 end
 
 parameter "param_project" do


### PR DESCRIPTION
### Description

Adds functionality to the Google Recommender policy. Specifically, it adds Cost and Currency fields to the incident output so that the user knows how much money is at stake, and it allows (optionally) the policy to filter by specific projects if desired by the end user. 

I have tested these changes and found no errors or problems.