### PR TITLE
Fix non-optimal array searching for costs

### DIFF
--- a/cost/aws/elb/clb_unused/CHANGELOG.md
+++ b/cost/aws/elb/clb_unused/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.12
+
+- Fix non-optimal array searching for costs
+
 ## v2.11
 
 - Debug log via param (off by default); use rs_optima_host instead of hardcoded hostname

--- a/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
+++ b/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.11",
+  version: "2.12",
   provider: "AWS",
   service: "ELB",
   policy_set: ""
@@ -318,7 +318,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
         s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
       }
 
-      // Constructing IntanceIds with comma separated to display in detail_template
+      // Constructing InstanceIds with comma separated to display in detail_template
       var instancesList = clb['instancesList']
       var s_instanceIds=""
       for(var j=0; j < instancesList.length; j++){
@@ -464,6 +464,17 @@ script "js_clbs_cost_mapping", type:"javascript" do
     return result+"."+values[1];
   }
   if(ds_billing_centers.length!=0){
+    // Put costs into a map by resource ID and only include them for resource IDs we actually need
+    var costs_by_resource_id = {};
+    _.each(clbs, function(clb) {
+      costs_by_resource_id[clb.id] = [];
+    });
+    _.each(clbs_cost, function(cost) {
+      var costs = costs_by_resource_id[cost.resource_id.replace(/^loadbalancer\\//, '')];
+      if (costs != null) {
+        costs.push(cost);
+      }
+    });
     // Format costs with currency symbol and thousands separator
     if( ds_currency_code['value'] !== undefined ) {
       if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
@@ -482,7 +493,7 @@ script "js_clbs_cost_mapping", type:"javascript" do
       var separator = ","
     }
     _.each(clbs, function(clb){
-      var cost_objects = _.where(clbs_cost, {resource_id: "loadbalancer/".concat(clb["id"])});
+      var cost_objects = costs_by_resource_id[clb.id];
       if (_.size(cost_objects) > 0){
         count++;
         var sum = _.reduce(_.compact(_.map(cost_objects, function(value){ return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
@@ -557,8 +568,8 @@ policy "policy_delete_unused_CLB" do
     escalate $esc_delete_clb
     summary_template "AWS Account ID: {{with index data.clbs 0}}{{ .accountId }}{{end}} - {{ len data.clbs }} Unused Classic Load Balancers Found in AWS"
     detail_template <<-EOS
-    {{data.message}}
-    EOS
+{{data.message}}
+EOS
     export "clbs" do
       resource_level true
       field "accountId" do
@@ -596,17 +607,17 @@ define delete_CLB($data,$param_log_to_cm_audit_entries) return $all_responses do
   $all_responses = []
   foreach $item in $data do
     sub on_error: skip do
-	$response = http_request(
-      verb: "get",
-      host: join(["elasticloadbalancing.",$item["region"],".amazonaws.com"]),
-      auth: $$auth_aws,
-      href: join(["/", "?Action=DeleteLoadBalancer", "&LoadBalancerName=", $item["id"], "&Version=2012-06-01"]),
-      https: true,
-      headers:{
-        "cache-control": "no-cache",
-        "content-type": "application/json"
-      }
-    )
+      $response = http_request(
+        verb: "get",
+        host: join(["elasticloadbalancing.",$item["region"],".amazonaws.com"]),
+        auth: $$auth_aws,
+        href: join(["/", "?Action=DeleteLoadBalancer", "&LoadBalancerName=", $item["id"], "&Version=2012-06-01"]),
+        https: true,
+        headers:{
+          "cache-control": "no-cache",
+          "content-type": "application/json"
+        }
+      )
       $all_responses << $response
       call sys_log('CLB delete response',to_s($response))
     end

--- a/cost/aws/gp3_volume_upgrade/CHANGELOG.md
+++ b/cost/aws/gp3_volume_upgrade/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Fix non-optimal array searching for costs
+
 ## v2.0
 
 - Initial Release

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "AWS",
   service: "EBS",
   policy_set: "GP3 Volumes"
@@ -433,6 +433,17 @@ script "js_volume_cost_mapping", type:"javascript" do
     return result+"."+values[1];
   }
   if(ds_billing_centers.length!=0){
+    // Put costs into a map by resource ID and only include them for resource IDs we actually need
+    var costs_by_resource_id = {};
+    _.each(volumes, function(volume) {
+      costs_by_resource_id[volume.volume_id] = [];
+    });
+    _.each(volume_costs, function(cost) {
+      var costs = costs_by_resource_id[cost.resource_id];
+      if (costs != null) {
+        costs.push(cost);
+      }
+    });
     // Format costs with currency symbol and thousands separator
     if( ds_currency_code['value'] !== undefined ) {
       if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
@@ -453,7 +464,7 @@ script "js_volume_cost_mapping", type:"javascript" do
     var total_savings=0;
     _.each(volumes, function(volume){
       console.log(volume.volume_id)
-      var cost_objects = _.where(volume_costs, {resource_id: volume["volume_id"]});
+      var cost_objects = costs_by_resource_id[volume.volume_id];
       console.log(cost_objects)
       var tags = volume['tags'];
       var tagKeyValue = "";

--- a/cost/aws/idle_compute_instances/CHANGELOG.md
+++ b/cost/aws/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.13
+
+- Fix non-optimal array searching for costs
+
 ## v2.12
 
 - Debug logs via param (off by default); use Optima host, not hardcoded hostname

--- a/cost/aws/idle_compute_instances/idle_compute_instances.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.12",
+  version: "2.13",
   provider: "AWS",
   service: "EC2",
   policy_set: "Idle Compute Instances"
@@ -661,6 +661,17 @@ script "js_instance_cost_mapping", type:"javascript" do
     return result+"."+values[1];
   }
   if(ds_billing_centers.length!=0){
+    // Put costs into a map by resource ID and only include them for resource IDs we actually need
+    var costs_by_resource_id = {};
+    _.each(instances, function(instance) {
+      costs_by_resource_id[instance.id] = [];
+    });
+    _.each(instance_costs, function(cost) {
+      var costs = costs_by_resource_id[cost.resource_id];
+      if (costs != null) {
+        costs.push(cost);
+      }
+    });
     // Format costs with currency symbol and thousands separator
     if( ds_currency_code['value'] !== undefined ) {
       if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
@@ -680,7 +691,7 @@ script "js_instance_cost_mapping", type:"javascript" do
     }
     var total_savings=0;
     _.each(instances, function(instance){
-      var cost_objects = _.where(instance_costs, {resource_id: instance["id"]});
+      var cost_objects = costs_by_resource_id[instance.id];
       if (_.size(cost_objects) > 0){
         count++;
         var sum = _.reduce(_.compact(_.map(cost_objects, function(value){ return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
@@ -753,8 +764,8 @@ policy "pol_utilization" do
   validate $ds_instance_cost_mapping do
     summary_template "AWS Account ID: {{with index data.idle_instances 0}}{{ .accountId }}{{end}} - {{ len data.idle_instances}} rows containing AWS instance CloudWatch utilization data"
     detail_template <<-EOS
-    {{data.message}}
-    EOS
+{{data.message}}
+EOS
     escalate $email
     escalate $terminate_resources
     check eq(size(val(data, "idle_instances")), 0)

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.16
 
 - Fix non-optimal array searching for costs
+- Fix currency bug caused by incorrect parameter being passed
 
 ## v2.15
 

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.16
+
+- Fix non-optimal array searching for costs
+
 ## v2.15
 
 - Use rs_optima_host instead of hardcoded hostname.

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.14",
+  version: "2.16",
   provider: "AWS",
   service: "EBS",
   policy_set: "Old Snapshots"
@@ -406,19 +406,30 @@ script "js_snapshots_cost_mapping", type: "javascript" do
     return result+"."+values[1];
   }
   if (ds_billing_centers.length!=0){
-  // Format costs with currency symbol and thousands separator
-  if( ds_currency_code['value'] !== undefined ) {
-    if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
-      var cur = ds_currency_reference[ds_currency_code['value']]['symbol']
-      if( ds_currency_reference[ds_currency_code['value']]['t_separator'] !== undefined ) {
-        var separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
+    // Put costs into a map by resource ID and only include them for resource IDs we actually need
+    var costs_by_resource_id = {};
+    _.each(snapshots, function(snapshot) {
+      costs_by_resource_id[snapshot.formatSnapId] = [];
+    });
+    _.each(snapshot_costs, function(cost) {
+      var costs = costs_by_resource_id[cost.resource_id];
+      if (costs != null) {
+        costs.push(cost);
+      }
+    });
+    // Format costs with currency symbol and thousands separator
+    if( ds_currency_code['value'] !== undefined ) {
+      if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
+        var cur = ds_currency_reference[ds_currency_code['value']]['symbol']
+        if( ds_currency_reference[ds_currency_code['value']]['t_separator'] !== undefined ) {
+          var separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
+        } else {
+          var separator = ""
+        }
       } else {
+        var cur = ""
         var separator = ""
       }
-    } else {
-      var cur = ""
-      var separator = ""
-    }
     } else {
       var cur = "$"
       var separator = ","
@@ -426,7 +437,7 @@ script "js_snapshots_cost_mapping", type: "javascript" do
   }
   var total=0;
   _.each(snapshots, function(snapshot){
-    var cost_objects = _.where(snapshot_costs, {resource_id: snapshot["formatSnapId"]});
+    var cost_objects = costs_by_resource_id[snapshot.formatSnapId];
     if (ds_billing_centers.length != 0 && _.size(cost_objects) > 0){
       var sum = _.reduce(_.compact(_.map(cost_objects, function(value){ return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
       var monthly_savings = sum*30;

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -263,7 +263,7 @@ datasource "ds_filter_ami_snapshots" do
 end
 
 datasource "ds_snapshots_cost_mapping" do
-  run_script $js_snapshots_cost_mapping, $ds_filter_ami_snapshots, $ds_snapshot_costs, $ds_currency_reference, $ds_currency_reference, $ds_billing_centers, $ds_get_caller_identity
+  run_script $js_snapshots_cost_mapping, $ds_filter_ami_snapshots, $ds_snapshot_costs, $ds_currency_code, $ds_currency_reference, $ds_billing_centers, $ds_get_caller_identity
 end
 
 ###############################################################################

--- a/cost/aws/unused_rds/CHANGELOG.md
+++ b/cost/aws/unused_rds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.10
+
+- Fix non-optimal array searching for costs
+
 ## v2.9
 
 - Added default_frequency "daily"

--- a/cost/aws/unused_rds/unused_rds.pt
+++ b/cost/aws/unused_rds/unused_rds.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "2.10",
   provider: "AWS",
   service: "RDS",
   policy_set: "Unused Database Services"
@@ -369,7 +369,7 @@ script "js_rds_instances", type: "javascript" do
 EOS
 end
 
-#get list of the rds instances thier properties
+#get list of the rds instances their properties
 script "js_rds_instances_set_request", type: "javascript" do
   result "results"
   parameters "region"
@@ -479,6 +479,17 @@ script "js_instance_cost_mapping", type:"javascript" do
       return result+"."+values[1];
     }
     if(ds_billing_centers.length!=0){
+      // Put costs into a map by resource ID and only include them for resource IDs we actually need
+      var costs_by_resource_id = {};
+      _.each(instance_list, function(instance) {
+        costs_by_resource_id[instance.name] = [];
+      });
+      _.each(instance_costs, function(cost) {
+        var costs = costs_by_resource_id[cost.resource_id.replace(/^db:/, '')];
+        if (costs != null) {
+          costs.push(cost);
+        }
+      });
       // Format costs with currency symbol and thousands separator
       if( ds_currency_code['value'] !== undefined ) {
         if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
@@ -498,7 +509,7 @@ script "js_instance_cost_mapping", type:"javascript" do
       }
       var total_savings=0;
       _.each(instance_list, function(instance){
-        var cost_objects = _.where(instance_costs, {resource_id: "db:"+instance['name']});
+        var cost_objects = costs_by_resource_id[instance.name];
         if (_.size(cost_objects) > 0){
           count++;
           var sum = _.reduce(_.compact(_.map(cost_objects, function(value){return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
@@ -541,10 +552,10 @@ policy "pol_unused_rds" do
   validate $ds_instance_cost_mapping do
     summary_template "AWS Account ID: {{ data.accountId }} - {{ len data.instance_list }} rows containing AWS RDS Unused Instances"
     detail_template <<-EOS
-    {{data.message}}
-    EOS
+{{data.message}}
+EOS
     escalate $email
-    escalate $decommision_rds
+    escalate $decommission_rds
     check eq(size(val(data,"instance_list")),0)
     export "instance_list" do
       resource_level true
@@ -597,18 +608,18 @@ escalation "email" do
   email $param_email
 end
 
-escalation "decommision_rds" do
+escalation "decommission_rds" do
   automatic contains($param_automatic_action, "Delete Instances")
   label "Delete RDS Instance"
   description "Delete selected RDS Instances"
-  run "decommision_rds", data
+  run "decommission_rds", data
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define decommision_rds($data) return $all_responses do
+define decommission_rds($data) return $all_responses do
   $$debug=true
   $$log = []
   $all_responses = []

--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.18
+
+- Fix non-optimal array searching for costs
+
 ## v2.17
 
 - Added default_frequency "daily"

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.17",
+  version: "2.18",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes"
@@ -631,6 +631,17 @@ script "js_volume_cost_mapping", type:"javascript" do
     return result+"."+values[1];
   }
   if(ds_billing_centers.length!=0){
+    // Put costs into a map by resource ID and only include them for resource IDs we actually need
+    var costs_by_resource_id = {};
+    _.each(volumes, function(volume) {
+      costs_by_resource_id[volume.volumeId] = [];
+    });
+    _.each(volume_costs, function(cost) {
+      var costs = costs_by_resource_id[cost.resource_id];
+      if (costs != null) {
+        costs.push(cost);
+      }
+    });
     // Format costs with currency symbol and thousands separator
     if( ds_currency_code['value'] !== undefined ) {
       if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
@@ -650,7 +661,7 @@ script "js_volume_cost_mapping", type:"javascript" do
     }
     var total_savings=0;
     _.each(volumes, function(volume){
-      var cost_objects = _.where(volume_costs, {resource_id: volume["volumeId"]});
+      var cost_objects = costs_by_resource_id[volume.volumeId];
       console.log(cost_objects)
       if (_.size(cost_objects) > 0){
         count++;

--- a/cost/azure/idle_compute_instances/CHANGELOG.md
+++ b/cost/azure/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.12
+
+- Fix non-optimal array searching for costs
+
 ## v2.11
 
 - Adding subscription filter to deal with timeout

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -7,11 +7,11 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.11",
+  version: "2.12",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle Compute Instances"
-  )
+)
 
 ###############################################################################
 # Parameters
@@ -411,6 +411,17 @@ script "js_instance_cost_mapping", type:"javascript" do
       return result+"."+values[1];
     }
     if(ds_billing_centers.length!=0){
+      // Put costs into a map by resource ID and only include them for resource IDs we actually need
+      var costs_by_resource_id = {};
+      _.each(instance_list, function(instance) {
+        costs_by_resource_id[instance.id] = [];
+      });
+      _.each(instance_costs, function(cost) {
+        var costs = costs_by_resource_id[cost.resource_id];
+        if (costs != null) {
+          costs.push(cost);
+        }
+      });
       // Format costs with currency symbol and thousands separator
       if( ds_currency_code['value'] !== undefined ) {
         if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
@@ -430,7 +441,7 @@ script "js_instance_cost_mapping", type:"javascript" do
       }
       var total_savings=0;
       _.each(instance_list, function(instance){
-        var cost_objects = _.where(instance_costs, {resource_id: instance['id']});
+        var cost_objects = costs_by_resource_id[instance.id];
         if (_.size(cost_objects) > 0){
           count++;
           var sum = _.reduce(_.compact(_.map(cost_objects, function(value){return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
@@ -470,8 +481,8 @@ policy "azure_resource_policy" do
   validate $ds_instance_cost_mapping do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): Azure idle compute instances found"
     detail_template <<-EOS
-    {{data.message}}
-    EOS
+{{data.message}}
+EOS
     check eq(size(val(data, "instance_list")), 0)
     escalate $email
     escalate $delete_resources

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7
+
+- Fix non-optimal array searching for costs
+
 ## v2.6
 
 - Debug via param (off by default, for EU app); use rs_optima_host instead of hardcoded hostname

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.6",
+  version: "2.7",
   provider: "Azure",
   service: "Storage",
   policy_set: "Old Snapshots"
@@ -259,7 +259,7 @@ script "js_get_costs", type:"javascript" do
         "User-Agent": "RS Policies",
         "Api-Version": "1.0"
       },
-	  ignore_status: [400]
+      ignore_status: [400]
     }
   EOS
 end
@@ -333,6 +333,17 @@ script "js_snapshot_cost_mapping", type:"javascript" do
     }
     // Format costs with currency symbol and thousands separator
     if(ds_billing_centers.length!=0){
+      // Put costs into a map by resource ID and only include them for resource IDs we actually need
+      var costs_by_resource_id = {};
+      _.each(snapshots, function(snapshot) {
+        costs_by_resource_id[snapshot.snapshot_id] = [];
+      });
+      _.each(snapshots_costs, function(cost) {
+        var costs = costs_by_resource_id[cost.resource_id];
+        if (costs != null) {
+          costs.push(cost);
+        }
+      });
       if( ds_currency_code['value'] !== undefined ) {
         if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
           var cur = ds_currency_reference[ds_currency_code['value']]['symbol']
@@ -351,7 +362,7 @@ script "js_snapshot_cost_mapping", type:"javascript" do
       }
       var total=0;
       _.each(snapshots, function(snapshot){
-        var cost_objects = _.where(snapshots_costs, {resource_id: snapshot["snapshot_id"]});
+        var cost_objects = costs_by_resource_id[snapshot.snapshot_id];
         if (_.size(cost_objects) > 0){
           count++;
           var sum = _.reduce(_.compact(_.map(cost_objects, function(value){ return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
@@ -387,8 +398,8 @@ policy "pol_azure_delete_old_snapshots" do
   validate $ds_snapshot_cost_mapping do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Old Snapshots Found"
     detail_template <<-EOS
-      {{data.message}}.
-    EOS
+{{data.message}}.
+EOS
     export "instances" do
       resource_level true
       field "subscriptionName" do

--- a/cost/azure/unattached_volumes/CHANGELOG.md
+++ b/cost/azure/unattached_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v.2.10
+
+- Fix non-optimal array searching for costs
+
 ## v2.9
 
 - Adding subscription filter to deal with timeout

--- a/cost/azure/unattached_volumes/azure_delete_unattached_volumes.pt
+++ b/cost/azure/unattached_volumes/azure_delete_unattached_volumes.pt
@@ -7,11 +7,11 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "2.10",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes"
-  )
+)
 
 ##################
 # User inputs    #
@@ -485,6 +485,17 @@ script "js_volume_cost_mapping", type:"javascript" do
     return result+"."+values[1];
   }
   if(ds_billing_centers.length!=0){
+    // Put costs into a map by resource ID and only include them for resource IDs we actually need
+    var costs_by_resource_id = {};
+    _.each(volumes, function(volume) {
+      costs_by_resource_id[volume.disk_id] = [];
+    });
+    _.each(volume_costs, function(cost) {
+      var costs = costs_by_resource_id[cost.resource_id];
+      if (costs != null) {
+        costs.push(cost);
+      }
+    });
     // Format costs with currency symbol and thousands separator
     if( ds_currency_code['value'] !== undefined ) {
       if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
@@ -504,7 +515,7 @@ script "js_volume_cost_mapping", type:"javascript" do
     }
     var total=0;
     _.each(volumes, function(volume){
-      var cost_objects = _.where(volume_costs, {resource_id: volume["disk_id"]});
+      var cost_objects = costs_by_resource_id[volume.disk_id];
       if (_.size(cost_objects) > 0){
         count++;
         var sum = _.reduce(_.compact(_.map(cost_objects, function(value){ return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
@@ -556,10 +567,10 @@ policy "pol_azure_unattached_volumes" do
   validate $ds_volume_cost_mapping do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Unused Volumes Found"
     detail_template <<-EOS
-    The following {{ len data.instances }} unused volumes, for Account: {{ rs_project_name }} (ID: {{ rs_project_id }}), have exceeded the specified age of: {{ parameters.param_unattached_days }} days old.\n
-    {{data.message}}
-    EOS
-  # Send email report
+The following {{ len data.instances }} unused volumes, for Account: {{ rs_project_name }} (ID: {{ rs_project_id }}), have exceeded the specified age of: {{ parameters.param_unattached_days }} days old.\n
+{{data.message}}
+EOS
+    # Send email report
     escalate $send_email_report
     # Delete the volume if user selected the delete option
     escalate $process_volumes
@@ -616,7 +627,7 @@ define delete_unattached_volumes($data, $param_create_snapshot,$param_log_to_cm_
   $all_responses = []
   foreach $item in $data do
     sub on_error: skip do
-      call sys_log("Infor item =",to_s($item))
+      call sys_log("In for item =",to_s($item))
       if $param_create_snapshot == "true"
         call create_snapshot($item) retrieve $status_code
         if to_s($status_code)=="202"

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6
+
+- Fix non-optimal array searching for costs
+
 ## v2.5
 
 - Added default_frequency "daily"

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.5",
+  version: "2.6",
   provider: "Azure",
   service: "Compute",
   policy_set: "Unused IP Addresses"
@@ -285,9 +285,9 @@ script "js_exclude_tags", type: "javascript" do
       //Exclude tags
       for(var i=0;i<param_exclude_tags.length;i++){
         if(_.has(ipAddress.tags, param_exclude_tags[i])){
-          isTagMatched = true;  
-		}
-	  }
+          isTagMatched = true;
+        }
+      }
 
       if(!isTagMatched){
         if(properties.ipConfiguration == null){
@@ -300,10 +300,10 @@ script "js_exclude_tags", type: "javascript" do
             tags:ipAddress["tags"],
             ipAddressId:ipAddress["ipAddressId"],
             savings:"N/A"
-		  })  
-		}
-	  }
-	})
+          })
+        }
+    }
+  })
   EOS
 end
 
@@ -335,6 +335,17 @@ script "js_ip_cost_mapping", type:"javascript" do
   if(ds_billing_centers.length!=0){
     // Format costs with currency symbol and thousands separator
     if( ds_currency_code['value'] !== undefined ) {
+      // Put costs into a map by resource ID and only include them for resource IDs we actually need
+      var costs_by_resource_id = {};
+      _.each(ip_list, function(ip) {
+        costs_by_resource_id[ip.ipAddressId] = [];
+      });
+      _.each(ip_costs, function(cost) {
+        var costs = costs_by_resource_id[cost.resource_id];
+        if (costs != null) {
+          costs.push(cost);
+        }
+      });
       if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
         var cur = ds_currency_reference[ds_currency_code['value']]['symbol']
         if( ds_currency_reference[ds_currency_code['value']]['t_separator'] !== undefined ) {
@@ -352,7 +363,7 @@ script "js_ip_cost_mapping", type:"javascript" do
     }
     var total_savings=0;
     _.each(ip_list, function(ip){
-      var cost_objects = _.where(ip_costs, {resource_id: ip["ipAddressId"]});
+      var cost_objects = costs_by_resource_id[ip.ipAddressId];
       if (_.size(cost_objects) > 0){
         count++;
         var sum = _.reduce(_.compact(_.map(cost_objects, function(value){ return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
@@ -425,9 +436,9 @@ end
 policy "pol_unused_ip_addresses" do
   validate $ds_ip_cost_mapping do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.ip_list }} Unused IP Addresses Found"
-	detail_template <<-EOS
-	{{data.message}}
-	EOS
+    detail_template <<-EOS
+{{data.message}}
+EOS
     check eq(size(val(data, "ip_list")), 0)
     escalate $send_email_report
     escalate $delete_unused_ip_addresses
@@ -482,7 +493,7 @@ define azure_delete_ip_addresses($ipAddressId) do
           query_strings: {
             "api-version": "2020-03-01"
           }
-        )    
+        )
     call sys_log($syslog_subject,to_s($response))
 end
 


### PR DESCRIPTION
### Description

- A number of Policy Templates for cost were looping through all of the costs they have retrieved from Optima on each iteration in order to find the costs relevant for each particular resource. This is inefficient and potentially causes evaluation timeouts that could be avoided. Instead, a map of only the relevant costs to resource IDs is constructed and used for fast lookups during iteration.
- Cleaned up some whitespace and spelling issues.

### Issues Resolved

POL-515

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
